### PR TITLE
[Design] : MainPage UI(초안), 페이지 이동 기능 구현

### DIFF
--- a/client/src/Components/Banner.tsx
+++ b/client/src/Components/Banner.tsx
@@ -17,6 +17,9 @@ const SlideContainer = styled(Slider)`
 	.slick-next::before {
 		color: #0db4f3;
 	}
+	.slick-slide {
+		padding: 0 40px;
+	}
 `;
 
 const SlideItem = styled.div<SlideItemProps>`

--- a/client/src/Components/Carousel.tsx
+++ b/client/src/Components/Carousel.tsx
@@ -13,6 +13,7 @@ interface SlideItemProps extends HTMLAttributes<HTMLDivElement> {
 const SlideContainer = styled(Slider)`
 	padding: 0 10px;
 	display: flex;
+	margin-bottom: 20px;
 	.slick-prev::before {
 		color: #0db4f3;
 	}

--- a/client/src/Components/Carousel.tsx
+++ b/client/src/Components/Carousel.tsx
@@ -20,6 +20,9 @@ const SlideContainer = styled(Slider)`
 	.slick-next::before {
 		color: #0db4f3;
 	}
+	.slick-slide {
+		padding: 0 30px;
+	}
 `;
 
 const SlideItem = styled.div<SlideItemProps>`

--- a/client/src/Components/CarouselHotPlace.tsx
+++ b/client/src/Components/CarouselHotPlace.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import Slider from 'react-slick';
+import 'slick-carousel/slick/slick-theme.css';
+import 'slick-carousel/slick/slick.css';
+
+import { HTMLAttributes } from 'react';
+import styled from 'styled-components';
+
+interface SlideItemProps extends HTMLAttributes<HTMLDivElement> {
+	image?: string;
+}
+
+const SlideContainer = styled(Slider)`
+	padding: 0 10px;
+	display: flex;
+	margin-bottom: 20px;
+	.slick-prev::before {
+		color: #0db4f3;
+	}
+	.slick-next::before {
+		color: #0db4f3;
+	}
+`;
+
+const SlideItem = styled.div<SlideItemProps>`
+	width: 220px;
+	height: 220px;
+	background-image: url(${(props) => (props.image ? props.image : '')});
+	background-position: center;
+	background-size: cover;
+	color: white;
+	font-size: 30px;
+	font-weight: 700;
+	border-radius: 15px;
+	text-align: center;
+	justify-content: center;
+	> div {
+		line-height: 220px;
+	}
+`;
+
+function CarouselHotPlace() {
+	// 옵션
+	const settings = {
+		dots: false,
+		infinite: true,
+		speed: 100,
+		autoplay: true,
+		slidesToShow: 4,
+		pauseOnHover: true,
+	};
+
+	return (
+		<div>
+			<SlideContainer {...settings}>
+				<SlideItem image="https://cdn.visitkorea.or.kr/img/call?cmd=VIEW&id=9c991ae8-67f8-4037-a3b3-dd2ed916a161">
+					<div>월미테마파크</div>
+				</SlideItem>
+				<SlideItem image="https://cdn.visitkorea.or.kr/img/call?cmd=VIEW&id=42c91d42-7f91-4c72-9794-8f93a2662228">
+					<div>백야자연휴양림</div>
+				</SlideItem>
+				<SlideItem image="https://cdn.visitkorea.or.kr/img/call?cmd=VIEW&id=a1ffcd56-ba0f-4171-a4a2-3111da89ec8c">
+					<div>대포해안</div>
+				</SlideItem>
+				<SlideItem image="https://cdn.visitkorea.or.kr/img/call?cmd=VIEW&id=786b4ca3-8549-47b6-a47e-368aa9b5b8dd">
+					<div>화암관광지</div>
+				</SlideItem>
+				<SlideItem image="https://cdn.visitkorea.or.kr/img/call?cmd=VIEW&id=7319438e-4e09-4fbd-9524-e25420bdd917">
+					<div>강천산 군립공원</div>
+				</SlideItem>
+			</SlideContainer>
+		</div>
+	);
+}
+
+export default CarouselHotPlace;

--- a/client/src/Components/CarouselHotPlace.tsx
+++ b/client/src/Components/CarouselHotPlace.tsx
@@ -20,6 +20,9 @@ const SlideContainer = styled(Slider)`
 	.slick-next::before {
 		color: #0db4f3;
 	}
+	.slick-slide {
+		padding: 0 30px;
+	}
 `;
 
 const SlideItem = styled.div<SlideItemProps>`

--- a/client/src/Components/CarouselReview.tsx
+++ b/client/src/Components/CarouselReview.tsx
@@ -1,0 +1,219 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import Slider from 'react-slick';
+import 'slick-carousel/slick/slick-theme.css';
+import 'slick-carousel/slick/slick.css';
+
+import { AiFillHeart } from 'react-icons/ai';
+import styled from 'styled-components';
+import img from '../Assets/전주.jpg';
+
+const SlideContainer = styled(Slider)`
+	padding: 0 10px;
+	display: flex;
+	margin-bottom: 20px;
+	.slick-prev::before {
+		color: #0db4f3;
+	}
+	.slick-next::before {
+		color: #0db4f3;
+	}
+	.slick-slide {
+		padding: 0 20px;
+	}
+`;
+
+const ReviewBox = styled.div`
+	border: 1px solid rgb(214, 217, 219);
+	height: 270px;
+	width: 210px;
+	margin-bottom: 20px;
+	margin-right: 45px;
+	background-color: white;
+
+	> div:nth-child(1) {
+		border-bottom: 1px solid rgb(214, 217, 219);
+		height: 200px;
+
+		> img {
+			width: 100%;
+			height: 100%;
+		}
+	}
+
+	> div:nth-child(2) {
+		padding: 5px;
+		font-size: 13px;
+		height: 40px;
+	}
+`;
+
+const Writer = styled.div`
+	height: 30px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	> div:nth-child(1) {
+		// 작성자 사진, 이름
+		padding: 5px;
+		display: flex;
+		width: fit-content;
+		align-items: center;
+		font-size: 12px;
+
+		img {
+			width: 20px;
+			height: 20px;
+			border-radius: 100%;
+			margin-right: 6px;
+		}
+	}
+
+	> div:nth-child(2) {
+		// 좋아요 부분
+		padding-right: 5px;
+		color: rgb(200, 202, 204);
+		display: flex;
+		font-size: 13px;
+		align-items: center;
+
+		> p {
+			margin-left: 4px;
+		}
+	}
+`;
+
+function CarouselReview() {
+	// 옵션
+	const settings = {
+		dots: false,
+		infinite: true,
+		speed: 100,
+		autoplay: true,
+		slidesToShow: 3,
+		pauseOnHover: true,
+	};
+
+	return (
+		<div>
+			<SlideContainer {...settings}>
+				<ReviewBox>
+					<div>
+						<img src={img} alt="여행리뷰사진" />
+					</div>
+					<div>재미따 ~</div>
+					<Writer>
+						<div>
+							<div>
+								<img src={img} alt="유저프로필사진" />
+							</div>
+							<div>너구리</div>
+						</div>
+
+						<div>
+							<AiFillHeart color="#F24F1F" size={17} />
+							<p>5</p>
+						</div>
+					</Writer>
+				</ReviewBox>
+				<ReviewBox>
+					<div>
+						<img src={img} alt="여행리뷰사진" />
+					</div>
+					<div>재미따 ~</div>
+					<Writer>
+						<div>
+							<div>
+								<img src={img} alt="유저프로필사진" />
+							</div>
+							<div>너구리</div>
+						</div>
+
+						<div>
+							<AiFillHeart color="#F24F1F" size={17} />
+							<p>5</p>
+						</div>
+					</Writer>
+				</ReviewBox>
+				<ReviewBox>
+					<div>
+						<img src={img} alt="여행리뷰사진" />
+					</div>
+					<div>재미따 ~</div>
+					<Writer>
+						<div>
+							<div>
+								<img src={img} alt="유저프로필사진" />
+							</div>
+							<div>너구리</div>
+						</div>
+
+						<div>
+							<AiFillHeart color="#F24F1F" size={17} />
+							<p>5</p>
+						</div>
+					</Writer>
+				</ReviewBox>
+				<ReviewBox>
+					<div>
+						<img src={img} alt="여행리뷰사진" />
+					</div>
+					<div>재미따 ~</div>
+					<Writer>
+						<div>
+							<div>
+								<img src={img} alt="유저프로필사진" />
+							</div>
+							<div>너구리</div>
+						</div>
+
+						<div>
+							<AiFillHeart color="#F24F1F" size={17} />
+							<p>5</p>
+						</div>
+					</Writer>
+				</ReviewBox>
+				<ReviewBox>
+					<div>
+						<img src={img} alt="여행리뷰사진" />
+					</div>
+					<div>재미따 ~</div>
+					<Writer>
+						<div>
+							<div>
+								<img src={img} alt="유저프로필사진" />
+							</div>
+							<div>너구리</div>
+						</div>
+
+						<div>
+							<AiFillHeart color="#F24F1F" size={17} />
+							<p>5</p>
+						</div>
+					</Writer>
+				</ReviewBox>
+				<ReviewBox>
+					<div>
+						<img src={img} alt="여행리뷰사진" />
+					</div>
+					<div>재미따 ~</div>
+					<Writer>
+						<div>
+							<div>
+								<img src={img} alt="유저프로필사진" />
+							</div>
+							<div>너구리</div>
+						</div>
+
+						<div>
+							<AiFillHeart color="#F24F1F" size={17} />
+							<p>5</p>
+						</div>
+					</Writer>
+				</ReviewBox>
+			</SlideContainer>
+		</div>
+	);
+}
+
+export default CarouselReview;

--- a/client/src/Components/Header.tsx
+++ b/client/src/Components/Header.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 import logo from '../Assets/logo.png';
 
 const Content = styled.div`
+	z-index: 1;
 	background: #fafafa;
 	width: 100%;
 	position: fixed;

--- a/client/src/Components/ScrollToTop.tsx
+++ b/client/src/Components/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+	const { pathname } = useLocation();
+
+	useEffect(() => {
+		window.scrollTo(0, 0);
+	}, [pathname]);
+
+	return null;
+}

--- a/client/src/Pages/HotPlace.tsx
+++ b/client/src/Pages/HotPlace.tsx
@@ -6,7 +6,7 @@ interface SlideItemProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 const backgroundImg =
-	'https://images.unsplash.com/photo-1618237586696-d3690dad22e3?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80';
+	'https://images.unsplash.com/photo-1601621915196-2621bfb0cd6e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1744&q=80';
 
 const HotPlaceContainer = styled.div`
 	width: 100vw;

--- a/client/src/Pages/HotPlace.tsx
+++ b/client/src/Pages/HotPlace.tsx
@@ -81,90 +81,96 @@ function HotPlace() {
 			</HotPlaceImage>
 			<HotPlaceItemContainer>
 				<HotPlaceItem>
-					<HotPlaceImg image="https://ak-d.tripcdn.com/images/1i6582224r13im1tt7998.jpg?proc=source/trip" />
+					<HotPlaceImg image="https://cdn.visitkorea.or.kr/img/call?cmd=VIEW&id=9c991ae8-67f8-4037-a3b3-dd2ed916a161" />
 					<HotPlaceInfo>
-						<span className="HotPlaceBold">여수의 큰끝등대</span>
-						<span className="HotPlaceBold">💙 9308</span>
+						<span className="HotPlaceBold">월미 테마파크</span>
 						<span>
-							전남 여수시 돌산읍 평사리 산1-1 이국적인 등대스팟으로 여수 핫플로
-							떠오르는 곳! 여수바다와 함께 하얀등대가 포인트 에요 등대에서
-							사진찍는게 꽤나 위험할수도있니 조심하세요!! 🌊 차량은 갓길 넓은
-							공간에 주차후 산길로 내려가야해요!
+							자연풍광이 뛰어난 월미도에서 1992년 개장이래 많은 사랑을 받아오던
+							마이랜드를 시작으로, 2009년 월미테마파크라는 4000평 규모의 대규모
+							시설로 재 탄생하였다. 월미테마파크는 지상 70M높이 하이퍼 샷·드롭
+							부터 월미도의 타가다디스코, 2층바이킹, 115M 대관람차 등어트랙션이
+							완비되어 있어 우리결혼했어요, 1박 2일, 런닝맨 등 다양한
+							방송출연지로 전국적인 유명세를 떨치고 있다. 2,500평 규모 실내
+							어린이 놀이체험관 차피패밀리파크와 물놀이 시설 미니후룸라이드,
+							물놀이보트, 물공놀이 등 어린이 놀이시설, 4D영상관 까지
+							어린아이부터 어른까지 모두가 즐길 수 있는 곳이다.
 						</span>
-						<span className="HotPlaceAuthor">여수너구리🥇</span>
 					</HotPlaceInfo>
 				</HotPlaceItem>
 				<HotPlaceItem>
-					<HotPlaceImg image="https://a.cdn-hotels.com/gdcs/production18/d110/a710493b-da6c-415d-bc2c-f63fc58cfeb0.jpg?impolicy=fcrop&w=800&h=533&q=medium" />
+					<HotPlaceImg image="https://cdn.visitkorea.or.kr/img/call?cmd=VIEW&id=42c91d42-7f91-4c72-9794-8f93a2662228" />
 					<HotPlaceInfo>
-						<span className="HotPlaceBold">한라산</span>
-						<span className="HotPlaceBold">💙 6555</span>
+						<span className="HotPlaceBold">백야자연휴양림</span>
 						<span>
-							제주도 중심부에 솟아 있는 한라산은 해발 약 1,950m의 용암이
-							분출하여 생긴 독특한 지형과 지질적 가치로 유네스코
-							세계자연유산으로 등재되어 있는 산입니다. 주변에는 흙붉은 오름,
-							사라 오름, 성널 오름, 어승생 오름 등 크고 작은 오름들이 많이
-							분포해있습니다. 한라산은 해발고도에 따라 아열대, 온대, 냉대 등
-							다양한 식물들이 자라는 곳으로, 한발 한발 내딛는 걸음마다 다채로운
-							풍경을 즐기실 수 있습니다. 또, 봄에는 철쭉, 진달래와 유채꽃이
-							펼쳐진 모습, 가을에는 단풍으로 물든 모습, 겨울에는 새하얗게 쌓인
-							눈과 운해가 만들어내는 모습으로 사계절 내내 사랑받는 산...
+							백야자연휴양림은 충북 음성군 금왕읍 백야리에 위치한
+							공립자연휴양림이다. 지정 면적은 37ha이다. 휴양림에는 숙박시설,
+							오토캠핑장, 수목원, 목재 문화체험장이 갖춰져 있다. 숙박시설은 총
+							29개소, 캠핑사이트는 26개소로 숲나들 e사이트를 통하여 사전예약 후
+							이용할 수 있다. 수목원에는 난대식물을 관찰할 수 있는 유리온실,
+							자라 모양을 닮은 자라암석원, 여러 종류의 장미를 구경할 수 있는
+							장미동산이 있다. 목재 문화체험장은 관람 및 목공예 체험이 가능한
+							공간이다.
 						</span>
-						<span className="HotPlaceAuthor">제주너구리🥇</span>
 					</HotPlaceInfo>
 				</HotPlaceItem>
 				<HotPlaceItem>
 					<HotPlaceImg image="https://res.klook.com/images/fl_lossy.progressive,q_65/c_fill,w_1200,h_630/w_80,x_15,y_15,g_south_west,l_Klook_water_br_trans_yhcmh3/activities/asckwf8sm8ij6bhjxi99/%EB%8C%80%EA%B5%AC%20%EC%9D%B4%EC%9B%94%EB%93%9C%20%EC%9E%90%EC%9C%A0%EC%9D%B4%EC%9A%A9%EA%B6%8C.jpg" />
 					<HotPlaceInfo>
-						<span className="HotPlaceBold">대구 이월드</span>
-						<span className="HotPlaceBold">💙 6002</span>
+						<span className="HotPlaceBold">제주 대포해안</span>
 						<span>
-							아름다운 넓은 공원, 매년 벚꽃 축제에서 다양한 이벤트가 열리고
-							내부의 조명 야경도 하이라이트가되었습니다. 음악 분수, 다양한
-							테마의 별빛 정원, 야외 밴드 공연 관람, 역동적인 음악과 함께 춤을
-							추고 주변에 많은 포장 마차가 있습니다. 배를 만족시킬 수 있고
-							모양이 매우 귀엽고 83 타워에 올라 탁 트인 전망을 볼 수 있으며 모든
-							종류의 흥미 진진한 모바일 게임을 시도 할 수 있으며 티켓은 별도로
-							구입할 수 있으며 여전히 매우 효율적 입니다.
+							용암이 식어 굳을 때 부피가 줄어들면서 6각형의 돌기둥으로
+							갈라지는데, 이러한 수직 방향의 틈을 주상절리라고 한다. 제주도에는
+							여러 곳에서 주상절리 지형을 볼 수 있는데, 그 정교함과 아름다움
+							면에서 대포 해안의 주상절리를 따라가기 어렵다. 천연기념물로 지정된
+							이곳의 주상절리대는 약 25만 년에서 14만 년 전 사이에 녹하지악
+							분화구에서 흘러나온 용암이 식으면서 형성된 것으로 추정된다.
+							제주올레길 8코스 중 최대볼거리인 대포 해안은 제주 국제컨벤션센터
+							앞 해안에서 시작해 대포 주상절리를 거쳐 대포포구까지 이어진다.
+							높은 주상절리 절벽에 새하얀 파도가 부딪히는 모습은 그야말로
+							예술작품을 방불케 한다.
 						</span>
-						<span className="HotPlaceAuthor">대구너구리🥇</span>
 					</HotPlaceInfo>
 				</HotPlaceItem>
 				<HotPlaceItem>
-					<HotPlaceImg image="https://newsimg.sedaily.com/2022/06/16/2679NT0CBD_5.jpg" />
+					<HotPlaceImg image="https://cdn.visitkorea.or.kr/img/call?cmd=VIEW&id=786b4ca3-8549-47b6-a47e-368aa9b5b8dd" />
 					<HotPlaceInfo>
-						<span className="HotPlaceBold">레고랜드</span>
-						<span className="HotPlaceBold">💙 4712</span>
+						<span className="HotPlaceBold">정선 화암관광지</span>
 						<span>
-							나는 공식 웹 사이트를 통해 2 일 티켓과 1 박 호텔 패키지를
-							예약했습니다. 크리스마스 정일 가격이 조정될 것이기 때문에 공식 웹
-							사이트는 2023 년 1 월부터 3 월까지 공원이 휴관 될 것이라고
-							언급했습니다. 겨울 공원에 들어가는 것이 관련이 있기 때문에 따라서
-							야외 모바일 게임과 물놀이 시설은 닫혀 있지만 어린이보다
-							카운터가있는 작은 게임이 있습니다. 레고랜드와 다른 느낌을 느낄 수
-							있습니다. 좋은 경험입니다. 5-12 어린이가있는 경우 동행, 놀이
-							시설은 그에게 더 적합해야하며, 전체 Li는 2 일 티켓을 천천히 재생할
-							수 있다고 말합니다.
+							정선군 화암면 화암리와 몰운리 일대 화암관광지는 빼어난 자연 경관을
+							자랑한다. 화암약수, 거북바위, 화암동굴, 물운대 등 화암8경이
+							구비마다 시선을 끈다. 유유자적 여행하다 잠깐씩 멈춰 서서 몸과
+							마음의 피로를 씻어낼 만한 여행지가 많다. 그 가운데 1경은
+							화암약수다. 화암약수는 탄산이온 성분을 함유하고 있어 탄산수처럼 톡
+							쏘는 맛이 특징이다. 나쁜 사람이 마실 때는 약수 안에 구렁이가
+							보인다는 전설이 있다. 2경인 거북바위와 3경인 용마소 등이 근처에
+							있다. 화암약수 야영장 또한 자연의 품 안에서 쉬어가기에 알맞다.
+							인근 그림바위마을은 한적하게 산책하기에 좋다. 화암약수 못지않게
+							유명한 곳이 4경에 해당하는 화암동굴이다. 화암동굴은 석회암동굴로
+							천연기념물이다. 1934년 금광 갱도를 파는 과정에서 그 모습을
+							드러냈다. 동굴 입구까지는 모노레일을 타고 이동할 수 있다. 동굴
+							내부는 옛 금광의 흔적과 석회암동굴이 공존한다. 동굴 길이는
+							1,803m로 돌아보는데 약 1시간 30분이 걸린다. 상부갱도와 하부갱도를
+							잇는 220m의 가파른 수직계단 등이 흥미롭다. 정선향토박물관,
+							천포금광촌, 화암카트체험장이 이웃해 화암동굴과 함께 돌아볼 수
+							있다.
 						</span>
-						<span className="HotPlaceAuthor">춘천너구리🥇</span>
 					</HotPlaceInfo>
 				</HotPlaceItem>
 				<HotPlaceItem>
-					<HotPlaceImg image="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAoHCBQVFBcWFRUYGBcXGxscGhkZGxkaIx0aHB0gHB0jHCMcICwjIBwoIBsbJDUlKC8vMjIyHSM4PTgxPCwxMjEBCwsLDw4PHBERHTMoIygzMTExMzEzMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMf/AABEIAKQBNAMBIgACEQEDEQH/xAAcAAABBQEBAQAAAAAAAAAAAAAAAgMEBQYHAQj/xAA/EAACAQIEBAQCCAUEAgEFAAABAhEDIQAEEjEFIkFREzJhcYGRBiNCUqGxwfAUYnLR4TNDgvGSsqIVFiQ0U//EABkBAAMBAQEAAAAAAAAAAAAAAAABAgMEBf/EACMRAAICAgICAwEBAQAAAAAAAAABAhEhMQMSQWETMlEiFAT/2gAMAwEAAhEDEQA/AOy4ruN1SlCoysVIAOoCSLj1HT1xY4qPpTH8LVnbSPzGFJ0mxxVtGCfj+ahx4tQVNLtp5YXSDb1EkDqbdMJ4fx7OsT9Y7Rp+6BzjWN/5SLdOu+KmtUCnVMjVzTJmbGep+7e0E4TwqsxpxTpyu0tUImWgGApJYWH5bY51O0dTgk9F030izLNpWq/QMRpIFrwY3/L8MSBxrNCPrWiR5ionnCgSP3v8KrJIRIYCZEkGxO5YGOszhWZJA1bKDSk9gXLHuNl2PbDUmDgi6r8erlFIrlDqYG0kKq3kH7RYLHv2Jx7l+NVxMu7AgGQxbQN76FKg7b9iMZvIPqCVW81SYkqIXUICzFyrXmQRMjfGhyWTg6VLnQqXCFBqA88kCYiNIEf07nRNsykki/yXE6h0rrYk+XWlzv2mdsXWTdohixPcjTPwO2MQuRqE6jpkMF1jlJMkEDSNXeSex9cavg1VvDIeNQJmDt2HpAi18VGyJJFoSe+PCx74ZZyfTFbmeLU18rF26BTb4n+04tJmZba274bbMqN6iie7DGVzOdq1PM1vurYfHv8AGcRPC9MV1FZrK3GaSWNTUeyjV+It+OGT9IaXTWfhjMrTHbDyJh9UKzR0uO0m6sPl+QM4kDitGY8VfnjKNQHoMeFAOuF1Q7NwryJBkHYi+PdRxjstnnpHla3Yi3y74lVfpE8DSqz3vHyOJaKTNQGwvGQHHatrgQPsgX95nDP8XUYzra+9zfpfvgoGzbYMY1M7WG1Rt56H8xiVR4xVG5De6jf4RgoVmowYz1Tjj9FH79xht+M1DtA+H53whmlwYydTiVU2DFR+Pzx4nEqw+1MdDgA1uDGco8bceYA26/4xY5fi1No1HSfXb54ALLBhCODsQfYzheAAwYMGAAwYMGAAwYMGAAwYMGADycVnHyP4d5uIEj01DDuIPG5/hqsb6R/7DEz+rKh9kc347lVWn4t5ZogGARpiLH0n54psijeGFkqwFuYj8jFoPzxqOMVQyoikEx+RuRN4mPxnETh3DmqvpLQBpJMdSyqQDsDBZo9PfHDHtVI7ZJWeU692ClZkEgAxEmwA5YiFMYi8TzWqktNSZZkgwQVAmTHtq9ZjE2hwupTZCBz87MRGmAAwAMQSdDgkTFp3EvVkps1R+RToBphQd7BwAPKx09Zs3QnFJSQsEfL51UZLkBIVQAvLCyRO92g/DGo4Zx2mNZqCZZQCJ2CgfG8298YytU1KWvbcnt3N/TDK1oBIk2JNx8z+OHHkmglxxeze8M4lSfSWe4DQINpYzJ6kkkz2xc0c1TQSB5rmBvax37Y5dQzmlFB1SIkj9fji1y3FtRGlwvUneTHqNvQfrjeHMtMwnwfjNTxDMs8yTo+7/fv8cNZagGU98UuX4kHeJ6n84+R6YvuFujrAYBpgC09f7Y3jyRejCXFKOyqqOVPXrPphKZ09RizzGXDsQZA31wSLd4E4q8wiaTBAI9Tf59caY8iFjPjtOGWzZucRcs6MQCWuYgDqdh1w3WV76YK3AllEj1IkjA6QkWVGszASPWb4dN9wMUSHMCwCdvMPUdb98TaGZqagjUxq06pD9O+0b4nSKq3gslpA2gzhT5Ug/jOICVCqtO4H4+kgj974U+cZtFzOkA9yYHpv88N4IW6Jook2GPUpnEdMy4kHUL2Bsf0m2PRm6o2c7/y/rg8D8llTuNsLNKbdcV1DNVGYgsY/44Y4i5JE7+wv8h+4xNj6lz4GAUu+KfI0gQZHUYm5LOs0lnsP5V2+Awdg6kzw8e+HjxM9T0kyTG4Ckme35D44Y/8AqyE+SpHQ6fzk2wCpj5pY8/hz0BwoZxLy6HqOcbf3+OPUz+slKYBeCR1FvXbAMTTpup1LIPcYtTxUhTKmQNx39oOM+M9Um5udrb/L3GFpm6jSJie6MJ9oE/PB1C2WPBuLuxbxCSNRiBsLdht/fF1/GJAJNiY6+u/yxlckppkyO0ST17gfriWmZBJlbYVDL989TA80+18RV4oIupmTYfhc4qUzQ+7hFTiIBssDCAtRn6hYcqgEi2/Xvi3xk6WeJdRAgkT8x/bF++598AybODEHBgEGIHHn05WqdoUf+w/cYn4rfpL/APqV5BPKLATPMLXxMvqxx+yMLwvLHMaixACmFDdzEa9M2YTEbaT6Y0FPKlKeipAu0wT5QJ33F2Y3tCn0xQcNVqYSoSIYkKJJhllQQIuyyD1MERuY0OaqAJqQHnJUhxINmMMIMpzMTJiBY7ThFKjqk3Ypa2gtTqKYA08scyR6CRBe/eLbxhhcsv8ADc0aoYxZruNx1gkiwO+nfEfN16hpudXMQSpS4cOCbBhMLsWjqe1/OG1qh1KApEA7HcRYAECAwAgCI69qsQzlOFeECKkQy81MCbDm6nzAwdOxBBExiu4pl1VF0rGnXcHzNA1RIgrZQCLDm720Lv8AVFxE00DATHOyyQI3lwv2rk9QRqg1OFVCstpZiAABA0nWJ1EjpeB1vAGJccUhqWbZl2p2iAYjpP474iNSKklZNzBj2+fuI36Y2GXyVOm3NHn0w0kkty8wUdoYXETNsD8HpqsudJOrYeWBYQCTubdTpAAkjE9WiuyM3l8xUW4iCQL29b4uaOdMA7EiSQdunTFPW8Q1AKY6gtBjtadow5XylSmGYAwxJkSw2Nu07dx7YhSSdJgy+zPElQKoJgqJEm5ME9d+uK/MZsMCWMdBvuTF77f5xS0s02xU6gbMB2PYDtifUQwOS/LF/UGb9N/3tr8zumZ/GqwTKNamDAcbiGII0xt3Hxw9n61OnT1Ek3gEXk+lr/4xW5CgajQDMAEzy9QD777DD/FuFQniKyiDpWmxDCIAkSTubx/1jeM72ZS460MJxWhaWI91cj8FxIp8VprBWqvsRUH6RjL1A4Mcp9bj9cI1v90fM/2xtSZGjaZj6R04YU2UBhB1FjA6jy39vzwxQ+kIUyFpuQJ5ddo92E/jjMZelUqGEp6j1iWgewE4veFeBSf65SY3BBJDDmAJWwb49P6hiW1EfWyRm+PrUbUZURAEEwOxMyeuHMtnUuHsbQYIgnYXJn9MJ4jw6g5WpQqLpYyytK6bdOXeZt+WI9WuoOgSTABeAB7DULx7LJjfpLkqwUosvC6pJBg7EDv1Ime2K7M8VQGAWYifuqCTeJ7T1ggYq6SVA0K9ib7kn4dcGayIkwNB2vMCPhiIzvY3As0+krLAKKpOxZyQPcBJjE7+PqU9IFNH8Qcul2I27lIIiYvsDigYqihGYuoiCbEe38vp0wtM+U5YBTfT0P8AY4pyXhC6lhRz5CxoWWkESe/XrOClmSJ5Y3ke+ISMs9DaZIAv6E3iOsYbfNabG9plSDaLbe4xEn+FxikWqZumql3si6dW8wTA/fphqj9JqdNwUmYgmDBB6b29/TEPh+YlapgMAVEMAwO/QiOs4iVskxbVop6Wvso3PaO2KWERJWzV5DM1HZQilVYBkdipUrAGweQLzeNj8ZL1lSVhG1CdWmDcnv8A94zdHLVETxFIUKNLNJFo2gbiCMTMqTpCmWN7QYva4W8dTAnFPKwQlUslrQzV/Tc+2F1c6I5ASJEgXI/EAfOcZ6vxEhjo8NOmnmke51X63Eew2w/QzdWpAYhlPRBDEAGyk3nrGGkN+i1fiKqeYNtOkBpE9J7i9vxOPRXSoTpkQOoP9h8YnFIiMCwYVFg9DYdxdTJ9Zt649WtpbzVVt1hvQzAAi/wwY8BRoMkZdTN9Qt3uNsbB9z74wXDOJIaiamOouo8hM3Hfyk9we9sb1tz7nCqhM8wYMGAQYj8RaKNQyBy9Yjf1sfbEjFd9IqujK1W+6FPXo6noQT8x7jfCehx2jIZjKKAGL66agmAdRAYyCoIkSw7yNRE97Ki6uijdGER0J0lSpaQbm8qN1aO+KPxjDBw4EmEe62OsrsNQAKGATZlEkwDJ1kwRUAlpZTukC8kHVYwR6nfmOMVg6XkQtMCopYoptChjr0qNIBBMEcrd/NHXE7KFaYASRTZuQagJ3crIYnZiAJgnre0JKZ1Ps3Mx2ZQCNMahsSd7yRJ7kYZyGYBDIWPhhmXVcACdQm+xBVY6D54SG0XWXzTaPqxcNqZTN/rCB/TZVItfSe9/AtMMHc6mS1iADpNrdyDtbSLAYrsmCCyq5Ilj5gAEUMQQQAZnUYIiFO43ZzXiNV0tKKsVKktBDQ2mWg6ZA36XvIGKsmi8p0w6lwBc1JYBgS8adpBBhSLbQTaScQ0qVGIBUkcy6vtFhMEA7XIkxsB64j06hAXUIA1bgnTABMk+rBZ3XUYvJxIObgM7XIWQJWBqdTvEhYIgEbAAG4xlyQU11ZSdEXi+QqUwznw9OowxIBIg3PQtCjFfmM8wWVsAYgEsI6ebc+s4e47xIVSYqNCAjSy71AL3MbGOnW1gMVCZuCQ6giIugv8ADmHScZ/5Y4S8DU62epx5gSDA3E23/Hr2xNy2eaossAOskEKZ3g7Xnbe9sVrcSCkgBlET9UKQF99WkAjofjhvL+HXLTVaFXUdQZuWQLAwJlgIxf8Alg/TE+RouDV8KpYGIERGx3wcV4iDTRAxBEFl0z6AnuYt6T864ZSisRUqn+jSn4NqGFVGpkAeFq07M7sSP/EqCMbQ45RVXZMppnlTKTTV0ZCGBMHlNv1BkEdIviLkzVonxFqAEi6g2K7xE7jv640OWzStoAQAS8Xj7IYbQLyBaLyeuKKtcAiAIt+HrYHbr0GKbdbJ606ayWa5+pVX/UeNoJj8okYrjSXV5R6np8cQy7BiUIJUSRGwsZPuJ3xOyrlwpJjVNz7THfp++k2VRGeo9NrCAegiCBv+xicmcpsvSD06/lef1xHqjVE7yYB6bRE7zvbp74tchwnxkBGq+xVdxqgGZFgANpmcHZ/gOK/SvpUiYKtCgwfKL9NxiQx52LKzAMbhpGkyYOk79tr/ABxLPBGSmz1aiU1VmIU01dojTuDMmLA9wQe9bw6ohJJWmUcEgix1BRYSbGwmRP5YpJsltIRxqk5FIhQupVEKepF92MgW/wA4RRyxCBS2kOCylzAAO0xcEgodr3xMNEzq1Ee1oHQD26YcqeJyqXPQwwB228wt6Y0cCIyJ+R4D4iEI6hvvgE/aBvtezduhnEelwxZOsyoRSzorkhFZkmDIvoaB2Yepw0mYrmEQ6hYaADsJIELAi5t64ezYqFteYKLqIXw0dqbMDJhoYwZY73v2OF0DsQMvxikkimlRCSTqDCTPckxtbp8cS6Wfeow0ZipuAVLX6bcxBETtifleDZJhqCM46h2aVPYwwj8jffFlQppT/wBKmiE/aVRJ9zF/jiVGX6Fopi1VKgatU00izg+Jq8oBi0bzHqfXFnwviIqA+DWZAnmQIoYibG0EgiPbbDWfybVLlixjr27do+WKg8OdXFRWKuh5Zk/C+46c3ePXGvWyLJVenTqV2FZ6qFiIdwDqtEkk8vYdPXpiyp8AloQPBHmHhmdJMWExvuCNtrYivxdYAq0WLiGApqH6kSObluD1wz/EU0daqJUWPMgUgNI+0TCjfoTcDBYUy9zXC6rKA7sdAMEoCfwbUT8zhun9HXaxeAbi0/O+KTiv0p8RWplDT2K+GZMT9uWF47eh9MVtLi9MatfjVJk8xAvtBKuTp+fthpNCeTSUOGLTqqGdGKutlcTMgiQY27Y3Tbn3OOZ5DiyvVpaKbyGRQdQaF1CxL05iw2+eOmNufc4lytj6tCcGDBhCDEDj1AvlayAgEqInvIPY4n4g8dUnLVQCAdIgmbHUI2uDOx74T0OO0c5r0K9JFappcXB1f7YFlEgxMidQElet7THFTw5i4Yk6bRBbTfedoB7e+JbVl0Bai1EDlb1FVSWY9vtAlbyNiewnyvVA1qCWF+VjMbgEC/lvAtMNcmZwao6kVeXR0LE0wROobGRpCm0jTckdRINsJydSKhFNQwMhTfqxA1LssDSDNvLHQYXUrqoBX7QCNETYi42Eja+0jEfwFUsqkghi6NqMxq06RBAk2NisyLjpJRd8MquoHOPrSihQpY6mY6mEHYSdp7noMP5p1amZYmo5BuEYg1EjSsAgoNJuOkmCd6nhGeqHQSWJ5RuzCSgWwEFrxf23NsWCU0YANLBbtrPmB536iNrgWMnfcWnghrI0M0glzBdlBiFmQI2A1OpPS1jBuBhviqs6moqFFIOolwoNNQSNW0mzXPt2OPc29IEMVZVt59RJBkGzGFmwHxnocKytRKyxJZjIVyQAkpMHcwdIsew5QBJaEyqyHB3ZZc2LOGY3YHTKgA3YGLESPMcTcpwu7GpqVSuoMGVokAiyyZuY6EqR64n52o0/epuo16QRqNgpBAjTCX6nxFEbYhZlw4iqhC0grimxEawh0JK8q7AxpuYG+zRLMznkqa/DRVqK+xp7ablZbSWsFBvbtIvhGRy9RawQUzLLBEgjSwY3sbA0yfcDD3HMrWqCnUGXWlqEr4YgqijSoIACqAqGJvyubKABSrmswCD4jEjYteIBAidrM3/ke+NFFkNo0NIlvEsF0EDmaZms9E7AbeGT8cSjlYVGtpbwybWg5gUmjqBpm8z1t0zWX4pVQNyIdUSY7MX9p1FjP9hEqlxdm0goRAIgOYPtqDBSb7ASZwNOgtFzwt2HhhdRIaprYrq0sVBAA6W0i3SxnbEB8tUc/wCoicpBRVEDSYsKYMXEg+gvF8SOGcYphWUZa7OrB6lSSmkKGB0U5KkKJAAgGMbn6PUqfhhwaR1A81OlpIDnUR1hbjlPSN8Jq9j7V4MhwXhtSo1QtT0UwtIO9U6FMIrQdmEhwSRvO98W1DJZWlR1VayqF1GFCqSTrgAnckBoUnb2nFbxHi5yqmlRg8xDu+p4IVRCgyCZDCTIBQ2tjP5riStrCtUbUVJ8XqwBuVVoUQbCW36bBqKJbZJ4pxekfqsrS0oReo8sQAQZUTpAFxefNEd0p9Kay2EFLQDJIsJg3tMxM9sVtOSCoVTriwW9jIiL/nue84sKP0fzDCTSKL1apFMDuecgx7A/HfGnVCtjo+kaN50f4EN8piPbHmWzNAVdYNVVj6zRYAmy65BET6Ei8TtiTS4LRUAvULkCGFLkUtJImo4nSV0rAEzeTNo/Ec0gQ0qdNfCtKoCIEySGaWd5UHUZ8sXuAl6B+zQaqUToqnrZ1gj/AIoZGPFzaLdKQnuxc/mwE/DGYyGdeiFv4lFjAO0E+86W3lTYx1scaYKCARswn3HwthOxnhz9U8oIReygC3soUfOcQ81w4VBMz6H9OgxJ0RHbC6bBdzpXudsLtWQqyryWaq0KigjWogSTDBTa5PmSO+1r2xq6PFKTk6W72IM2uT7bYryKYGttLLEggjrItJBwxlnp8y09LyragxiYnlk7evt74xl/0RvA1Atn4lSH2wx7Le/wmMR/Er1LU6JA+9UE/GJxS5XiS0DLmjSgG4hmG9gmo9L9LknEPN/SmpU1KuqoLhTzzG8mSApIuegxp/UtMqLjHas0eWzdXLlytUOLeIdKkLcjSpjmEg7bRfDTfSXUfrMulQyBemGmxNgokev+MZFM1VLBhSpzYnXfVFwCARPf8TAN3MtlM21rG3QMog3NiUWPbth9BOafgsc3RNVmqqopqTAXRo2AmwE9Rve43wZTgzO+l6i04gyel4FmgmTYESMIY5vUtI6UJuagNWBuedtUA2N/YHpiQKFCkCtRkq1Gm+k6FP8AMTq36M0DfbGjlSozSt2bThXB/CAC8zkgF3VRaRIAUQNvU+vTGqbc+5xy7gvF83SqUkamTTd0AGvWFUtAKlubSB6kY6i259ziKocm3s8wYMGAkMR+JNpoVDBMLPKJIg7iO2/wxIw3mwPDedoB6jYg9MJ6GtmFziMzsVKFNSmwNzYTPW5Hx0nEbP0CqLMBzpAAKgCDAssAGAe3Tc4vKVOlTDsByE6mU6jDEyxJOwEwZsB6aphcQRWdU0qNSkgkm0A3Em94gHt64xkdCZm3ogOuptIfSVgizER16An5Ycqvz0npwSyMpAO1QjzC3MITb0HtiYcopKtV0kKGXTAUArBEbSYBbrYj0iA7amp0gWRUqsmpvuurVASwMM+lmFzJKi/aEi2xdGo9NVKrvTAEgesAARM8hB323JvNyeTq1PPvBUajzeYgEgf8rSCZn3jVM0NFEEqzuQZMFvDKaV6GILhrXOkTucTl4wF0xeSNRMaQo5ZaFtABF8NITZKHDRTaSPEYqdRZl7R1HKNUC172vvZkBVIZ+Xbc7AcywNxp69jtjOUeI0wDKgkk6S1MKItCj7Aud56ye2JVHPseQBWFQSriKkG5EbSQBYzvaNppEsa4pU8IaDVpqr6yreEWYAgcytIkagIi9xGwxWUswxqBqJbSukcqu5A1apY3JBgnex7FicXZVKqFqgVWYAo1QqxlRKa/5ZZGiROpQbGMYvjGhajLTaoQPMXIktMny9J0+s/8cawVmcnRY8b47UceErtAs55Vki0cjEFR6kyewBxQgfv9/v47eT+/3+/e0qX9/u/77/a2SozeRSp+/wDr4fh/KMO08rq3B6Htb9x8+ttSFE/vp+P679Z55+TZ6nLS0wvmJtJnv1v0mb9d8EnQJCGymrlSxPmPUCDF9vX433nE7hmarUWsRpIkRAsY3AEHf92xHqZkIAizbeTJPax6zfptfDIqEzfSDvt5Tci022jaPc455SbNlFFwXp1VIakrMXqOVclrO2oimQw5ZZ203PMY2OFh1UALSogAAD6pmtFo1aunzxV06hWFXcHl7Eb9J2vYd/TFxlq61QfvCzevqI3ncgb7iDhxaeSZRawIXP1AIQso+6op0hHW6C2/4g7GcMEVD2tsWl23j7Xr0iZtYwGkssH9++/zM+5++MJZf+o+G34R/wAfuEa0iCEaE+YluxkGAe3TY+1/uk6Gcxlrfrf8evTr2J3VsWBX97/ibHcXNjqBNnfAB+/l3+G/8s7PLEZ98uyEsoBB8yHyt79jY3FwQewOLfhWaXRoVWOgGVLcy3PQ7i+69rjqXKlAdB8rdvl09uXqrYr6+SOoMpKsCIYcsf27+l+2G0mJOiS+dc+LEL4RZSO7LSqvv2miB0MN0xUZms70UYk62anMer5gb9oRP/EYuM5TqI7tToqUdpB5jMKymSp0k/WVJ/qveMO5ehUfS1JJ5ObSNISoBqOllO6jUYkTPocYOMjVSiQ3TW2gO2p6jwXHJOqwE3BHKsm09seZ/wCjljGYFSDemQ1MhrAiEDLqAEHpIxdrwfSQ9equsCBp5jEGNyRvFwWkH4Y8zPFKdOFRRM6Rq+sYG82AsQDuANgYkTg4+NrLJlIz2X4MF1M9NVpbioCH8t9gSdJEkf0yZsQHimUWyh6pMAAAxINh3mYOx79sM8VzdWodVMkCVaYuTuNvVjFzO4m8IymdpsdNVRTf/wDoBMkkSSBuSAQXF+4Jvjcmx9eN1CR4VBEkkamNyBubESBuT/nDRrZqp/qVmVbE6Bp5OhtHMxgD4YlvRgSQIeAIuGH2UQzcTdvjsRBfA62LFuUDY1OpkkDQgsOk4dBZTfwNRG1IzFwb9ZdvKl9zEyY79oNnlc7TqHRUCqysd40kgmSp+z0vPysMTsvRLAKh1FtS0z0varVaB1NgT2v3xHz3DFdgI8MEchMylFDLPe3MfjE4lxBMteG5UJUpwsfWLJPfUN5uT79sdSfc+5xxXgmcqUq1FagJRnTQ0XUGoFBYgddoNt4jr2p9z7nEUDE4MGDAIMMcQcik5AkgC0TNxb47YfxC44xGWqkGCAP/AGGFLTHHaMnXz5UryEaoAkFbGNhPrsTaTe96anm5qKCRtyrtB3MSLC39NiOoxIzdR0KwyuDMGYYTcgarRpYDpJEeuK/MooqqS0pqBJGkWO89jBNr45HI6izz5erUKtpggdbTLCDsRZ4tOx6AAVPFqqpTWouqFCDVHeQCZ3GpzE76oEbia9AqhqAABbgbAhbxvC2kWAFyDsMQ+JZtP4aqrao5QIAG0OJWRuSbRIk9MaIm8Dgpo1XwlEBBDXhTJkAEmN9PN1IgC2BcslM6mQrczIExHQHfY/hAtiPkMx4ZFVy5CgluknTO/mLEkx7DuThitFSooFTSkaig1KBAm8iSbWtY9B1pMVC6zhmELFN+XSCIKwCNRuAJiYAuBNoxZHjXhQBqC81kR0AIAkU9S7LcEb3NoIxWVzSUpocsyuA6nnCjpcaBJMCCfxIBmUEp1wHVTrGkS1LxA9ibKAZABIIEXJJuFGJyyk0jW0c3TIKmmFCtDIfDWTptqB3Nh87wRAyH0oyOVCg0VIqBQFC8oIN9dQaReSQAAJkdLCZxajmaChlLWktVp0qbGFO1TWVCTvMlT1Ag6sNU4jmEZmqKRMmNIAknYQAsX+yMXlCj0byJmqvmWfXD2Xrat1YH26/u3ucWRrxo8RV511CJ7AxcevfErJV6LsNQaBOqIOnreDETHUe43w1ySKnxw2mRMtXDoEWzJqJmJNhYADaQT13PfCyrIfMdQETN7yPve4tFviQ/nKIkPS0MtwwUXVRMkgkMCLkm+0g4h+K2shUZptfryzYE3P6YpT/THr+BTroIDJPTUp0taYE7E+4brFr48Z0YXqKGIHnBiLkXUH0MECDgzLFGBZdBgWI3Np9TJ7/OwGG2dCbQZgdRvsN+kgwdowmotjTaLWhRZxyKrlZ8rAmYbop1e0W/EYbLsjQyujLYapE7xE9dvwxEfKqyCTpIm1vTe9tjf2+ErK5LM6eR6qj+sgfnBt0GEoVlDc8Uy4yWbFVdoYTPYkDUYK2BAGqB21C8jFjSyGpVCka2k7yNEWnSDpNo3AggSOSIfB6BoGXqBmsVUDZiZU/oJEX9sSs7xggMXOm8kGAZiLqLyNrxbbGuTJsjvlGkWB1CQRBBn12O52sZMWdThD0CNyCfefW/pfrEy33rRsjli9UVfFPhVtevliPDAMgeJzaZAmZEkxYxK/jKCjkQsSBBYyAwMtYaVKnbbv3tQgSiTMKTA9/fVb87mWMDViYciAG8QhYkEWJkXho2mZEmD1MnFXmeNGdAIWdWlEEkg7qAu+wsR+WIB4izEaRIJhSx3tdVGwqA/YaCbRuMMC6XKZWmS3NV0zBqtKKAQRC2TT5pnVvNsR85xc7IZMhYp9CDZNVhqALQouegOKtlZ/MxN4vAGqIjS3Kr96VXe+lrjClQdBMyoAE7G6AVPMVInwn5hEq22ABS5uowAECeqgySBeD526yqw69UYYYNMXJ5pBM2uATc7qFnc3UG5Wkb4eibG+qxCy+rTuL81SLHQ5WolipOFAE3neWmS2oiZYERqIEHWv1q3DBt8AhspaD6WAM80nYkklgJ3Oq8NVHKIOdyKsLgRe9jtAsZvBgT0tJTyYtFUG0bgm8XU+Y2EMh31AeGSDrRDzYSw+ciSTsSIW+qxhrANJUwlRhyYAooKVarQmOdDIIYHt8CCATcQw9Jxc8NrU6x5SR0ZDBIQXIpmJYk72BM7G5DWYy47T/LEQFuQBAiJE2BWZKU5L4qczkPtKYPYdZ2t1n8ehffAI06lGBuAD5gP9ukv2Zm7dNveJGJFRmddIMFxrqkCyUgJVb3n/Pe+XyHFVVgMzSFQfelkcHaQ6kEmLQ07ASMaullMi4Rkr1aYcEjUykcpUc2sGSCRBk9YsLJsqiNRou9WkrRqd6VRyCDppoylEETC2HoYGxnHW33Pucc8ynAKhqI6ZhKqs6FiRBfQwJ5lZlPl2CjYbb46G259ziW7BoTgwYMIQYrfpK0ZSsSY5ReQPtDucWWI/ElDUagIkFRbfqMZ8kusZS/Exx+yOVtmNI0sQqi4AAJ39TESfT9cJWXJEHS14Yfai+roTvt3xJ4hw5kB0nWCZ5Vn4kAW67epxUnMAHQbX62vsfmRO03sMcPHyqatHWXeazJVQjQxYEDSziI+8CI1bGdr9IxS5oiag0AF3ErYmAEMWO2qDF/L63RJmQxJLGwAWATPvpIvcWjvvJdQfrItqJ0QBIkCLg2k9r7Xxp2dCVUVuXdmQCo7aqamFbYFZMksQNRAFgOi2JGJNfMLUqoq7QBAjeIiTJ2Aj02jEtsrTaRSaSTTYBpmwAOqTJbVqO/246ABvLcOWlU1KTJMm+0srjcaetj1j1GKlIRB8E03aoAQNYF9SEibkgW6dBFvgNHleM00pl/CNTVGolwDMgBRMnTcQbTMxqJwmtw8laRILnXDFnkFSoiVNwt5noAcV/8JTpsQ4FVL6tAkQZi9gYkHpPbFxlTE0pYLEfS+jTjTl31fzsARfpYmPljOcbnMMz0wlNHMFEkCZN2BOksb3G+LDM8PQKIJ0dByn2Om4EyY2Nr4arZLlhSQBa0Neb2Ji3obdsbOTeyFFLRBztaVpKyEFFgyPRRP/xxVZjNinAQbySe/TY/8sWSiosgcy3sLx7qbz6x8cQ85w6rXdfCpFgFiRZRcm7MYG5tOFVhdE3hGYZ3qKdJ0UqrTcWAHYyD7HE05w3LIrRpJYQCJUQd5Ijre/YYaoCll9XiHVVZXQrSaRoeZMlYDLAECdx8XE+kGWSNFGWhQCWDGwgbpAPtilF0KyXQqvUh1UkD7wYqZseYxP8A8hHXC2+j6OwmZMwtMjudR1NCiBHS2ned62v9LnLcqxtaW/Oxj44b4T9JnSoXNNGUyGDCLMZbSYJk9pg9cUoryS5PwX9KlRowoVZW0swLRG8sSQZ9sMZnjqiylmJjy25ukWJIN7fsV2U+j1asSURtEiNbQqg3vME26if1xoMl9FaUw9TXDwadIBoP8x3G19o2xeESZ5+I1XBCBaak6bTYelyTN4E39r4ZbhtRkNQpVqIDcqDEAEm4ExAu23SRjo9LhlKkCVp0qZU8tWqde8SbxFpEThvM/SHKo16zObctMSu+/RT8zttiXNLZUYuWkctBemS4OkA7AwR7dZ64tkzS1+sM0SFYU1cibgiAtW/2joPULvjR8U4Ll83NTKNTNQCWpmV1TABgkBIjtBnGGrUmV2PKmmQU22sQR3nFKnoTtYZamgoBUhYY6Tq+rVm6BxY0K0fajS3tJLwPmn01mouxny5hR+FULMnefLGyPElqiHgGAslS3L0V12dB0BusyhGxlOuiDMKglSpDtTS6mNVqtAmRFiuxANixDhIvM8oAbV9YVRrr4mmRVobQ4hltH2ZVNiW20gsDz8nrB+uo9nBLpHphtJBVVFxJQISbffyzGCyyTqpFj163VSHYrfUSyqh0amEBjRMTTq3E0mBBm3SAQ4w3G9gTq5gVA5WfSJqU42qqAy9ehwrqZuYDGTrMCdLkpd1G3ioQ46g4QgMDSRGrlK8g1zMrNqNa10ICt06Y9VxHTSDvPhgPJkdfArTffQ3sLgxxtr7eeZ2uIeU3g/7tOf51wHa/KACRsIS0mwK6O5RWpsDzKpvjwNEnqpliQyaWgXeL0na31iHQ0CRvj3Y9fvQBHoHIpxG8GrSJBHmW+AQ0ykWgADSTNoA8sgtYAixdtMH6uou2LDh/Dqb/AFrEimWMeUsw2vII5rEgC9tWoycVGfr6KZe4H2Y0kajvBUeHO4LIRIPMk3w1xXj1M06VKm7RTAmACpt3kXGE5JbH1bqi049wjLUzTPMRV8iOQhA7sxBVUHf0gKInDT0uF0gyKald2H+mgOnULghiPEA6EobibYy2ZztSu0xVqN3dy9uwIAgfHE/KfR3OVFggUqfUG0/8V8x+M4ycm9FqKWydwj6TVVq01VgrVa1MMwUFimtVCDolMCRAgjtjtr7n3OOOfR7g+TTMItR3Z1KsrFVVdQYRCyW1THm/CDjsb7n3OGk/IpNeBODBgwyAxB46+nK1iOij8xidiq+lJ/8Awq/9I/8AYYjkVwa9MqP2Rz5+O06ZIbUbGY9Z2v8ArjOUXLVNYASTALbarAXa4MkSTA+OGaxmdh6xvFo+Zn4k4ZCxpIPbYxcfvffbHm8XDGFtHRKTZf0MyFYKIaIBILEMTcRaJsBuSfhGPOJGmVp04A1jykiQutgRJ3IP4jDWQGqalRQwGncgXBG3eZI69BhrPvGZoFohKc/HWxM+5WfjjaLyxrRoaAdk0sS4IEEtFwbiJknf31dhGGjTdGIckhtEKObVEixA8wIj23xBOaNQHQTYiaignpMjaIHf8Nse+IykCS0G0wbb/esZ/wA4WaEyelVkJ8OxuQGUEG0CRe5JAJ3/AFaqurbKoBtqAmTcGVk6RYGVJ9sJpkkkabQSOkfDvI2PTDLRcAXkiYi/Xc+98VBtIpRsneFSXSQ9OI2WZMfAQLCBbEDMNTd4VUpg/bqMQBHoNuvm/DCXTXJsItMaQNo3nqT2NxhGWpkzzA+4ieu5Hudx8Zxt3IcBa5OnTqBvGWqVIIKjWoImxCkg/EgYhcVzNZkKvUFRbcwEGOg2HLPoPhhyo1MszUixUwC1wdQ83SNIaYnpisd2dtLO4Bi6gMZF77Wtc/ni1IhokVOGqJcFXSwFRQYvP2WAM269cJXI0+YKCSLNBBJPq0QoNxY4h5xigVfq3psQbGzEA3M8ym8bLMbWnFhka4agC41kIiiZBFlEgiDNhc6hjRTS2S4WeLlKcMFAgAErMID/ADMGJY9DH4YazGVUAtYKAIdgVUf0JHMfUm/rhS5pXYIpkhST4sBVZRMLB0mRpAJA5j0wsVj5p0lvtvDMQDHIoEDaDftjVTi9GbhJZI+WzdbL/wCnUdVP2TzFtj5JgfEbHEjNfSbOGor69LqABTQW9WeZXUe8Y8q0zeAyTYm7VGI6AE277YiNQttAYWRbs39Rjb42w3EVln/9xU6rTmKWpgOarTdlI+B1LO3bElKOVqx4WYUEzC1Ro+Cssr87/pnXpXAIk9KY2H9V98MtRM25m9PKvyxnLji/BrHllHTNUchmaDCqqsukyKiQ6/NZEd9UD03i5IpcSQK8UsyuxAkOADYd1uSRuvqMYTI8Vr0jFKo4jcyQv+cXOV+lKvfMUVeI+tp/VOD94FYv8Onyhcbi/wCWVPkU1/Sz+oruI8LqU6ml4Qp2BgjeRa4I64f4VxMSKbGADYyVKnYsp6Eix3UizAjGyfjGSzlLw3qcw8rOFDqbXB8s2EwROMdx3hVSkQspofmSoojUoJ3kWaIJXpONTIsa2VIEQrByeRToDtuGpXIpV4+xsYOnWLBouCC0qQ5gs40o7D7FZRanW3ioCO83LYq6efNFzTLo8hZ3KNtY94gQbEQCIInFypFQNUpsFeObVcFdytUf7lP+eNQ+3trwwAsJbXMgQ+samCEiBWX/AHafliqhkWMTpGFF21AQQ0WEh2KdQpMCvRIAtqLL6xdhJVgoVwyXCKZqIrXmi62q0jM6D0NrS2PQwKkkp4YMkrq8PVNmYJD0KltwsHtGAQ4jwFKkACyOGYLsbUqrAFCLzSqmPnh1VE6dPNM6dJBBI83hglgDHnottBjDYLKZnSWtqZlVm2/3CBSroR96Ce/eTTy9UqfCpFghjS6jQrfzJWLKu86keLXGACP/ABB1sqUGzDsAGAD1BeRFUBQGA71VBF5PXFPV4IzVCBS0vuKVE+LHSTBcCbWnvYYvjQr120VMy9QjelQBq6R6kaaSD1kjHtehUVRSqZlKVIAAUqf1jHpzLThCx3JLTJxDjbtlqWKRL+jNKtTbw6gpkASFXQagjqfCGkL3LlYt8UcVzILMK+ZOmbUaEXA21v5Qe8B/fDdbhFOkt6zUQfOHZalRtiv1dOFSINmab4a4fVyIcqEkAEmpW+sJjotMQhJ/mmL3w9BV5JfDsxlPqbKmuohWnTAZ5FSB4tV5O99C9O2OqPufc45VQ43RXMUzRoqGepTBquFLXKryiAqW+4Bjqr7n3OJFITgwYMBIYqPpYD/BZjTvoEQJ+0OnXFvj0MRthNWqGnTs4HUpVNZik4m/+m32vhhJyVQX0PAmAqtIPeCBbbr/AHx3/We5waz3OMfg9l/J6OCslQJdKhJCiAGPXqI9BP8A1LlZC6pUalU1qQnlJBCknmBFz5vQ98d21nucGs9zg+Ffo/kOG0WqLfRVCzyzTIsDOoJF9x+Pc4mpUqVAQUaOnIw3gX5YA7Xx2XWe5waz3OF8HsPl9HHqWVqWiYAkzbaYgnqflcfCSKZp2CNPcBiZNoMdhjrGs9zg1nucNcKXkfzejjmYSpNk3sRDRa/aRecNPSqeHr0ODpnRpsTEgALfew1Se5nHaNZ7nBrPc4pcdEvkOC5LK1CkGnUkVDujff6CIGHBlaggaH8zX0n19I647trPc4NZ7nD+MXc+es/kqjBAKdW2mdSMI1HT29Df+4xLfhWYp015CY0k6QTssXBHf9jHetZ7nBrPc4Hx+xrkrwfO2WydXWS1N9iPKdxpBgxe0fpietOsBpAqhZmAGiYiY2mABjvWs9zg1nucD47d2aR/6KVUcCyNepUZzVpVKUrY0qdQnUIt9Y2xg9bE9Rs4uSqaA+kjUSpIBL6gJMg3CnvtjvOs9zg8Q9zjVNowbTODDLVAukI6LeZB1HuDC2w2+Rcrem6oLwEaW/fbHffEPc4PEPc4ruTR8+vw+oRzUnCjZFUye0wPxwVOHPAZ6bx9mmEf+344+gvEPc4PEPc4OwHzs/Dqkamp1BPlUKfx6x640VL6R5tafhVqAq0zA0eGdhceVYgQI9sdn8Q9zg8Q9zhdhnAlpsGOikwBBAL0iSoO3TcbSPX2xqPozWUAJ4CKqqed0Id6i7nxG06GJmDtJGwvjqviHucHiHucHYDjjUatVTV8ALTNQqlBh4bACCShJGh5LHsT3gDCRRqFidNVnWZOlqVYL2cMClYADvJ6wMdl8Q9zg8Q9zgUgOQZTJVHnw6bMD5jSQLIPStQfStvvLAG89cJq8GrPUFOrWOkWp06WuqQq7C5FNFCjcuY647D4h7nB4h7nA5AsHJn4OtJSgrPSQwXVZrOzCd9AVAIMRqMYXQ4JTZCyUqgBBitmKhSDtqSnTGpoNxIYSMdW8Q9zg8Q9zhWV2OO1MtlqZJZa2Ze/2WpJPwlz76h7Ym1+G1atNfFWllKQOtUSmDUJKkA6FvMMfOQcdV8Q9zg8Q9zhB2OT8OGWo1aQpZZ6r+Ig8aupcjmAlV0hEI7gT646w+59zg8Q9zhOATdhgwYMAgwYMGAAwYMGAAwYMGAAwYMGAAwYMGAAwYMGAAwYMGAAwYMGAAwYMGAAwYMGAAwYMGAAwYMGAAwYMGAAwYMGAAwYMGAAwYMGAAwYMGAAwYMGAAwYMGAAwYMGAD//2Q==" />
+					<HotPlaceImg image="https://cdn.visitkorea.or.kr/img/call?cmd=VIEW&id=7319438e-4e09-4fbd-9524-e25420bdd917" />
 					<HotPlaceInfo>
-						<span className="HotPlaceBold">전주 한옥마을</span>
-						<span className="HotPlaceBold">💙 3888</span>
+						<span className="HotPlaceBold">순창 강천산 군립공원</span>
 						<span>
-							전주 풍남동 일대에 위치한 국내 최대 규모의 전통 한옥촌이자 전국
-							유일의 도심 한옥군인 전주 한옥마을은 한옥의 고즈넉한 아름다움을
-							느낄 수 있는 마을입니다. 마을에는 경기전, 오목대, 향교 등 중요
-							문화재와 20여개의 문화시설, 그리고 한복 체험, 한옥 스테이 등
-							다양한 체험 공간이 있어 남녀노소 모두가 좋아하는 관광지입니다.
-							한복을 입고 마을을 거닐다보면 어느새 타임머신을 타고 과거로 와있는
-							듯한 느낌이 드는 곳이랍니다. 다양한 길거리 음식과 전주를 대표하는
-							베이커리, 전주 여행 필수 맛집들도 있으니 잊지 말고 꼭 들러보세요.
+							전북 순창군 팔덕면 청계리 996번지 일대에 위용을 자랑하고 있는
+							강천산 왕자봉(해발583.7m)과 광덕산 선녀봉(해발578m)을 비롯하여
+							산성산 연대봉(해발603m)을 중심으로 세개의 산 사이로 병풍을
+							둘러치듯이 남록과 북록으로 나뉘어 작은 협곡을 이루고 있으며,
+							사방이 모두 바위산으로 빼어난 아름다움을 간직한 자랑스러운 산이다.
+							골짜기마다 단단한 암반위로 깨끗하고 맑은 물이 샘처럼 솟아
+							흐른다하여 강천이라 불렀고 그 주변의 모든 산을 강천산이라 하였다.
+							예전에는 용천산(龍泉山)이라 불렀다고 한다. 두 마리의 용이 하늘을
+							향해 꼬리를 치며 승천하는 형상이라 지어진 이름이다.
 						</span>
-						<span className="HotPlaceAuthor">전주너구리🥇</span>
 					</HotPlaceInfo>
 				</HotPlaceItem>
 			</HotPlaceItemContainer>

--- a/client/src/Pages/MainPage.tsx
+++ b/client/src/Pages/MainPage.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import Banner from '../Components/Banner';
 import Carousel from '../Components/Carousel';
@@ -15,7 +16,7 @@ const MainContainer = styled.div`
 `;
 
 const MainTab = styled.div`
-	width: 100%;
+	width: 90%;
 	height: 70px;
 	display: flex;
 	justify-content: space-between;
@@ -23,10 +24,9 @@ const MainTab = styled.div`
 	padding: 20px;
 `;
 
-const MainTabButton = styled.span`
-	width: 25%;
+const MainTabButton = styled.div`
 	text-align: center;
-	font-size: 30px;
+	font-size: 24px;
 	padding: 10px;
 	border-radius: 15px;
 	margin-top: 20px;
@@ -52,6 +52,11 @@ const MainContentsContainer = styled.div`
 const SlideContainer = styled.div`
 	width: 90%;
 	height: 270px;
+	text-align: end;
+	font-weight: 600;
+	> span {
+		color: #0db4f3;
+	}
 `;
 
 const BannerContainer = styled.div`
@@ -71,11 +76,14 @@ function MainPage() {
 				<MainTabButton>지역별 추천 여행 명소</MainTabButton>
 				<MainTabButton>국내 핫한 여행 명소</MainTabButton>
 				<MainTabButton>인기 여행 리뷰글</MainTabButton>
-				<MainTabButton>커뮤니티</MainTabButton>
+				<Link to="/community">
+					<MainTabButton>커뮤니티</MainTabButton>
+				</Link>
 			</MainTab>
 			<MainContentsContainer>
 				<SlideContainer>
 					<Carousel />
+					<span>전체보기</span>
 				</SlideContainer>
 				<BannerContainer>
 					<Banner />

--- a/client/src/Pages/MainPage.tsx
+++ b/client/src/Pages/MainPage.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import Banner from '../Components/Banner';
 import Carousel from '../Components/Carousel';
 import CarouselHotPlace from '../Components/CarouselHotPlace';
+import CarouselReview from '../Components/CarouselReview';
 import MainHeader from '../Components/MainHeader';
 import UserHeader from '../Components/UserHeader';
 
@@ -51,9 +52,8 @@ const MainContentsContainer = styled.div`
 `;
 
 const SlideContainer = styled.div`
-	width: 90%;
-	height: 270px;
-	text-align: end;
+	width: 85%;
+	text-align: right;
 	font-weight: 600;
 	> span {
 		color: #0db4f3;
@@ -61,10 +61,10 @@ const SlideContainer = styled.div`
 `;
 
 const BannerContainer = styled.div`
-	width: 90%;
+	width: 85.5%;
 	height: 200px;
 	margin: 50px 0;
-	padding: 10px;
+	padding: 0px;
 `;
 
 function MainPage() {
@@ -84,7 +84,7 @@ function MainPage() {
 			case 1:
 				return <CarouselHotPlace />;
 			case 2:
-				return <CarouselHotPlace />;
+				return <CarouselReview />;
 			default:
 				return <Carousel />;
 		}

--- a/client/src/Pages/MainPage.tsx
+++ b/client/src/Pages/MainPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import Banner from '../Components/Banner';
 import Carousel from '../Components/Carousel';
+import CarouselHotPlace from '../Components/CarouselHotPlace';
 import MainHeader from '../Components/MainHeader';
 import UserHeader from '../Components/UserHeader';
 
@@ -68,22 +69,73 @@ const BannerContainer = styled.div`
 
 function MainPage() {
 	const [isLogin, setIsLogin] = useState(false);
+	const [currentTab, setCurrentTab] = useState(0);
+
+	console.log(currentTab);
+
+	const handleTabClick = (index: number) => {
+		setCurrentTab(index);
+	};
+
+	const renderCarousel = () => {
+		switch (currentTab) {
+			case 0:
+				return <Carousel />;
+			case 1:
+				return <CarouselHotPlace />;
+			case 2:
+				return <CarouselHotPlace />;
+			default:
+				return <Carousel />;
+		}
+	};
+
+	const moveToPage = () => {
+		switch (currentTab) {
+			case 0:
+				return (
+					<Link to="/">
+						<span>전체보기</span>
+					</Link>
+				);
+			case 1:
+				return (
+					<Link to="/hotplace">
+						<span>전체보기</span>
+					</Link>
+				);
+			case 2:
+				return (
+					<Link to="/hotreview">
+						<span>전체보기</span>
+					</Link>
+				);
+			default:
+				return <span>전체보기</span>;
+		}
+	};
 
 	return (
 		<MainContainer>
 			{isLogin ? <UserHeader /> : <MainHeader />}
 			<MainTab>
-				<MainTabButton>지역별 추천 여행 명소</MainTabButton>
-				<MainTabButton>국내 핫한 여행 명소</MainTabButton>
-				<MainTabButton>인기 여행 리뷰글</MainTabButton>
+				<MainTabButton onClick={() => handleTabClick(0)}>
+					지역별 추천 여행 명소
+				</MainTabButton>
+				<MainTabButton onClick={() => handleTabClick(1)}>
+					국내 핫한 여행 명소
+				</MainTabButton>
+				<MainTabButton onClick={() => handleTabClick(2)}>
+					인기 여행 리뷰글
+				</MainTabButton>
 				<Link to="/community">
 					<MainTabButton>커뮤니티</MainTabButton>
 				</Link>
 			</MainTab>
 			<MainContentsContainer>
 				<SlideContainer>
-					<Carousel />
-					<span>전체보기</span>
+					{renderCarousel()}
+					{moveToPage()}
 				</SlideContainer>
 				<BannerContainer>
 					<Banner />

--- a/client/src/Pages/MainPage.tsx
+++ b/client/src/Pages/MainPage.tsx
@@ -58,7 +58,6 @@ const SlideContainer = styled.div`
 	> span {
 		color: #0db4f3;
 	}
-	z-index: -1;
 `;
 
 const BannerContainer = styled.div`

--- a/client/src/Pages/MainPage.tsx
+++ b/client/src/Pages/MainPage.tsx
@@ -58,6 +58,7 @@ const SlideContainer = styled.div`
 	> span {
 		color: #0db4f3;
 	}
+	z-index: -1;
 `;
 
 const BannerContainer = styled.div`
@@ -65,6 +66,7 @@ const BannerContainer = styled.div`
 	height: 200px;
 	margin: 50px 0;
 	padding: 0px;
+	z-index: -1;
 `;
 
 function MainPage() {

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,5 +1,6 @@
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import ScrollToTop from './Components/ScrollToTop';
 
 import App from './App';
 
@@ -8,6 +9,7 @@ const root = ReactDOM.createRoot(
 );
 root.render(
 	<BrowserRouter>
+		<ScrollToTop />
 		<App />
 	</BrowserRouter>,
 );


### PR DESCRIPTION
🐕 결과물

메인페이지(게스트)
<img width="1470" alt="스크린샷 2023-05-04 16 06 14" src="https://user-images.githubusercontent.com/119163273/236137971-037aad60-4c43-42dd-9fd4-b7ffc58865e2.png">

메인페이지(유저)
<img width="1470" alt="스크린샷 2023-05-04 16 06 28" src="https://user-images.githubusercontent.com/119163273/236138027-0d3597a6-d8e9-4bf5-bac3-1d5a7ae76089.png">

각 탭 클릭 시 캐러셀 컴포넌트 변경
캐러셀 루프, 자동재생
<img width="1470" alt="스크린샷 2023-05-04 16 06 48" src="https://user-images.githubusercontent.com/119163273/236138191-cd00808f-d58c-4e8c-af22-3e87cf6fbf74.png">
<img width="1470" alt="스크린샷 2023-05-04 16 06 53" src="https://user-images.githubusercontent.com/119163273/236138189-b2d905ad-8d92-453c-a768-2ce7e609c17d.png">
<img width="1470" alt="스크린샷 2023-05-04 16 07 05" src="https://user-images.githubusercontent.com/119163273/236138181-ed55fa93-926d-4485-9ca2-c1b72fe26bb2.png">

전체보기 버튼 클릭 시 각 탭 내용 상세페이지로 이동 / 커뮤니티 탭은 커뮤니티로 이동
<img width="1470" alt="스크린샷 2023-05-04 16 18 58" src="https://user-images.githubusercontent.com/119163273/236138371-6a1075fc-7461-4a6f-b0be-ff0061427500.png">
<img width="1470" alt="스크린샷 2023-05-04 16 23 35" src="https://user-images.githubusercontent.com/119163273/236138356-e9626655-e7d9-425b-8674-99091f282aee.png">

🐕 추가 전달 사항
 - 캐러셀 컴포넌트 문제로 Header에 z-index : 1 설정했습니다.
 - 데이터는 하드코딩 된 상태입니다
 - 여럿 수정해야 할 부분이 아직 많고, 디테일은 그보다 우선순위를 한 단계 더 뒤로 두고 수정 예정입니다!
- [ ] 서버에서 데이터를 받아 회원 별 mbti에 따른 멘트와 이미지 로드
- [ ] 지역별 추천 여행 명소 페이지 구현
- [ ] 인기 여행 리뷰 top5 는, 실제 사이트에 작성된 리뷰 중 추천수가 높은 게시글을 받아오는 기능을 어떻게 구현해야할 지 고민중입니다!
- [ ] 핫한 여행지 페이지를 외부 링크를 연결해 관광 정보 사이트에 연결 고려중입니다
- [ ] 그 외 스크롤 이벤트나, 글자 위치, 색상, 사이즈, 반응형 웹 디자인 적용하기 등.....이 있습니다
