### PR TITLE
[Feat] : 전체 지역 조회 페이지, 이미지 지연 로드 적용

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,6 +25,7 @@ import Login from './Pages/Member/Login';
 import Logout from './Pages/Member/Logout';
 import UserEdit from './Pages/Member/UserEdit';
 import RegionRec from './Pages/RegionRecommend';
+import Search from './Pages/Search';
 
 const MainPage = lazy(() => import('./Pages/MainPage'));
 const Mypage = lazy(() => import('./Pages/Member/Mypage'));
@@ -59,6 +60,7 @@ function App() {
 					<Route path="/loading" element={<Loading />} />
 					<Route path="/regionrec" element={<RegionRec />} />
 					<Route path="/regiondetail/:id" element={<RegionDetail />} />
+					<Route path="/search" element={<Search />} />
 				</Routes>
 			</Suspense>
 			<Footer />

--- a/client/src/Components/Header.tsx
+++ b/client/src/Components/Header.tsx
@@ -2,7 +2,7 @@ import '../Global.css';
 
 import { AiOutlineSearch } from 'react-icons/ai';
 import { useSelector } from 'react-redux';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import logo from '../Assets/logo.png';
@@ -66,6 +66,7 @@ const Content = styled.div`
 `;
 function Header() {
 	const login = useSelector((state: RootState) => state.login) as Ilogin;
+	const navigate = useNavigate();
 
 	const locationNow = useLocation();
 	if (locationNow.pathname === '/logout') return null;
@@ -78,6 +79,7 @@ function Header() {
 		const el = e.target as HTMLFormElement;
 		// eslint-disable-next-line no-console
 		console.log(el.search.value);
+		navigate('/search');
 	};
 	return (
 		<Content>

--- a/client/src/Components/MainHeader.tsx
+++ b/client/src/Components/MainHeader.tsx
@@ -11,7 +11,7 @@ const MainHeaderContainer = styled.div`
 	width: 100%;
 	height: 640px;
 	padding-left: 100px;
-	margin-top: 71px;
+	margin-top: 82px;
 	display: flex;
 	align-items: center;
 	scroll-snap-align: start;

--- a/client/src/Components/UserHeader.tsx
+++ b/client/src/Components/UserHeader.tsx
@@ -17,7 +17,7 @@ const UserHeaderContainer = styled.div<UserHeaderImgProps>`
 	width: 100%;
 	height: 640px;
 	padding: 100px;
-	margin-top: 71px;
+	margin-top: 82px;
 	display: flex;
 	align-items: center;
 	&::before {

--- a/client/src/Pages/HotPlace.tsx
+++ b/client/src/Pages/HotPlace.tsx
@@ -11,7 +11,7 @@ const backgroundImg =
 const HotPlaceContainer = styled.div`
 	width: 100vw;
 	height: 100%;
-	margin-top: 71px;
+	margin-top: 82px;
 `;
 
 const HotPlaceImage = styled.div`

--- a/client/src/Pages/HotReview.tsx
+++ b/client/src/Pages/HotReview.tsx
@@ -27,7 +27,7 @@ const backgroundImg =
 const HotReviewContainer = styled.div`
 	width: 100vw;
 	height: 100%;
-	margin-top: 71px;
+	margin-top: 82px;
 `;
 
 const HotReviewImage = styled.div`

--- a/client/src/Pages/RegionDetail.tsx
+++ b/client/src/Pages/RegionDetail.tsx
@@ -39,7 +39,7 @@ type TripInfoType = {
 const RegionDetailContainer = styled.div`
 	width: 100vw;
 	height: 100%;
-	margin-top: 71px;
+	margin-top: 82px;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;

--- a/client/src/Pages/RegionRecommend.tsx
+++ b/client/src/Pages/RegionRecommend.tsx
@@ -168,7 +168,7 @@ function RegionRec() {
 		const options = {
 			root: null,
 			rootmargin: '0px',
-			threshold: 0.5,
+			threshold: 0.4,
 		};
 
 		const lazyObserver = new IntersectionObserver((entries, observer) => {

--- a/client/src/Pages/RegionRecommend.tsx
+++ b/client/src/Pages/RegionRecommend.tsx
@@ -18,7 +18,7 @@ const backgroundImg =
 const RegionRecContainer = styled.div`
 	width: 100vw;
 	height: 100%;
-	margin-top: 71px;
+	margin-top: 82px;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;

--- a/client/src/Pages/RegionRecommend.tsx
+++ b/client/src/Pages/RegionRecommend.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from 'react';
+import { HTMLAttributes, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -51,6 +51,9 @@ const RegionRecItemContainer = styled.div`
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: center;
+	.unvisible {
+		background-image: url('');
+	}
 `;
 
 const RegionRecImg = styled.div<SlideItemProps>`
@@ -161,6 +164,27 @@ function RegionRec() {
 		},
 	];
 
+	useEffect(() => {
+		const options = {
+			root: null,
+			rootmargin: '0px',
+			threshold: 0.5,
+		};
+
+		const lazyObserver = new IntersectionObserver((entries, observer) => {
+			entries.forEach((entry) => {
+				if (entry.isIntersecting) {
+					entry.target.classList.remove('unvisible');
+					observer.unobserve(entry.target);
+				}
+			});
+		}, options);
+		const images = document.querySelectorAll('.regionItem');
+		images.forEach((el) => {
+			lazyObserver.observe(el);
+		});
+	}, []);
+
 	return (
 		<RegionRecContainer>
 			<RegionRecImage>
@@ -172,8 +196,9 @@ function RegionRec() {
 							<StyledLink
 								to={`/regiondetail/${item.id}`}
 								style={{ textDecoration: 'none' }}
+								key={item.id}
 							>
-								<RegionRecImg image={item.img}>
+								<RegionRecImg className="unvisible regionItem" image={item.img}>
 									<div>{item.name}</div>
 								</RegionRecImg>
 							</StyledLink>

--- a/client/src/Pages/Search.tsx
+++ b/client/src/Pages/Search.tsx
@@ -1,0 +1,222 @@
+import styled from 'styled-components';
+
+const SearchContainer = styled.div`
+	width: 100%;
+	height: 100%;
+	margin-top: 82px;
+	padding: 20px;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+`;
+
+const SearchAd = styled.div`
+	width: 90%;
+	border: 1px solid #d9d9d9;
+	border-radius: 15px;
+	padding: 20px;
+	display: flex;
+	flex-direction: column;
+	font-size: 24px;
+	font-weight: 700;
+	.keyword {
+		color: #0db4f3;
+	}
+`;
+
+const AdItemContainer = styled.div`
+	width: 100%;
+	display: flex;
+	justify-content: center;
+`;
+
+const AdItem = styled.div`
+	width: 20%;
+	height: 300px;
+	border: 1px solid #d9d9d9;
+	border-radius: 15px;
+	padding: 10px;
+	margin: 10px;
+	.adimg {
+		width: 100%;
+		height: 70%;
+		border-bottom: 1px solid #d9d9d9;
+	}
+	.adtext {
+		width: 100%;
+		height: 30%;
+		font-weight: 300;
+		font-size: 20px;
+	}
+`;
+
+const SearchResult = styled.div`
+	width: 90%;
+	border: 1px solid #d9d9d9;
+	border-radius: 15px;
+	margin-top: 50px;
+	padding: 20px;
+	display: flex;
+	flex-direction: column;
+	font-size: 24px;
+	font-weight: 700;
+	.keyword {
+		color: #0db4f3;
+	}
+`;
+
+const ResultContainer = styled.div`
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	padding-top: 10px;
+`;
+
+const ResultItem = styled.div`
+	width: 95%;
+	height: 210px;
+	border: 1px solid #d9d9d9;
+	border-radius: 15px;
+	padding: 15px;
+	margin: 12px 0;
+	display: flex;
+`;
+
+const ResultText = styled.div`
+	width: 80%;
+	display: flex;
+	flex-direction: column;
+	.subject {
+		margin-right: 20px;
+	}
+	.content {
+		padding: 10px 30px;
+		height: 120px;
+		font-size: 20px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.author {
+		text-align: end;
+	}
+`;
+
+const ResultImg = styled.div`
+	width: 20%;
+	border: 1px solid tomato;
+	border-radius: 15px;
+	margin-left: 20px;
+`;
+
+function Search() {
+	return (
+		<SearchContainer>
+			<SearchAd>
+				<div className="title">
+					<span className="keyword">키워드</span> 추천 여행지
+				</div>
+				<AdItemContainer>
+					<AdItem>
+						<div className="adimg">사진</div>
+						<div className="adtext">텍스트</div>
+					</AdItem>
+					<AdItem>
+						<div className="adimg">사진</div>
+						<div className="adtext">텍스트</div>
+					</AdItem>
+					<AdItem>
+						<div className="adimg">사진</div>
+						<div className="adtext">텍스트</div>
+					</AdItem>
+					<AdItem>
+						<div className="adimg">사진</div>
+						<div className="adtext">텍스트</div>
+					</AdItem>
+					<AdItem>
+						<div className="adimg">사진</div>
+						<div className="adtext">텍스트</div>
+					</AdItem>
+				</AdItemContainer>
+			</SearchAd>
+			<SearchResult>
+				<div className="title">
+					<span className="keyword">키워드</span>가 포함된 게시글
+				</div>
+				<ResultContainer>
+					<ResultItem>
+						<ResultText>
+							<div className="resultInfo">
+								<span className="subject">말머리</span>
+								<span className="title">제목</span>
+							</div>
+							<div className="content">
+								내용이 진짜 길면 어디까지 늘어날까요내용이 진짜 길면 어디까지
+								늘어날까요내용이 진짜 길면 어디까지 늘어날까요내용이 진짜 길면
+								어디까지 늘어날까요내용이 진짜 길면 어디까지 늘어날까요내용이
+								진짜 길면 어디까지 늘어날까요내용이 진짜 길면 어디까지내용이
+								진짜 길면 어디까지 늘어날까요내용이 진짜 길면 어디까지
+								늘어날까요내용이 진짜 길면 어디까지 늘어날까요내용이 진짜 길면
+								어디까지 늘어날까요내용이 진짜 길면 어디까지 늘어날까요내용이
+								진짜 길면 어디까지 늘어날까요내용이 진짜 길면 어디까지
+								늘어날까요내용이 진짜 길면 어디까지 늘어날까요내용이 진짜 길면
+								어디까지 늘어날까요
+							</div>
+							<span className="author">작성자</span>
+						</ResultText>
+						<ResultImg>img</ResultImg>
+					</ResultItem>
+					<ResultItem>
+						<ResultText>
+							<div className="resultInfo">
+								<span className="subject">말머리</span>
+								<span className="title">제목</span>
+							</div>
+							<div className="content">내용</div>
+							<span className="author">작성자</span>
+						</ResultText>
+						<ResultImg>img</ResultImg>
+					</ResultItem>
+					<ResultItem>
+						<ResultText>
+							<div className="resultInfo">
+								<span className="subject">말머리</span>
+								<span className="title">제목</span>
+							</div>
+							<div className="content">내용</div>
+							<span className="author">작성자</span>
+						</ResultText>
+						<ResultImg>img</ResultImg>
+					</ResultItem>
+					<ResultItem>
+						<ResultText>
+							<div className="resultInfo">
+								<span className="subject">말머리</span>
+								<span className="title">제목</span>
+							</div>
+							<div className="content">내용</div>
+							<span className="author">작성자</span>
+						</ResultText>
+						<ResultImg>img</ResultImg>
+					</ResultItem>
+					<ResultItem>
+						<ResultText>
+							<div className="resultInfo">
+								<span className="subject">말머리</span>
+								<span className="title">제목</span>
+							</div>
+							<div className="content">내용</div>
+							<span className="author">작성자</span>
+						</ResultText>
+						<ResultImg>img</ResultImg>
+					</ResultItem>
+					<span>◀︎ 1/25 ▶︎</span>
+				</ResultContainer>
+			</SearchResult>
+		</SearchContainer>
+	);
+}
+
+export default Search;


### PR DESCRIPTION
🐕 수정사항 
<img width="1470" alt="스크린샷 2023-05-15 19 39 03" src="https://github.com/codestates-seb/seb43_main_023/assets/119163273/29eb69d9-af04-4445-819a-a254f99c0d9e">
(👆🏻 3GS 환경에서 이미지 지연 로드 적용 전, 화면 진입 시 테스트 결과)
<img width="1470" alt="스크린샷 2023-05-15 19 40 09" src="https://github.com/codestates-seb/seb43_main_023/assets/119163273/bf7ad4e6-2c03-44ac-966e-63d0c7d3f0e9">
(👆🏻 3GS 환경에서 이미지 지연 로드 적용 후, 화면 진입 시 테스트 결과)

 - 해당 화면 진입 시, 일부 이미지가 지연 로드 됩니다(초기 진입 시 1440*1024 기준 위에서 부터 2줄(총 8개)의 이미지가 로드되고, 이후 스크롤을 내릴 때 마다, 뷰포인트에 요소가 40% 이상 들어오면 이미지가 로드됩니다)
 
<img width="1470" alt="스크린샷 2023-05-16 02 00 24" src="https://github.com/codestates-seb/seb43_main_023/assets/119163273/508b8004-10f1-445e-bf0a-3b395996c54f">

 - 검색 결과 페이지 레이아웃 구현했습니다. 시간 내에 기능구현이 끝날 지 모르겠지만, 우선 레이아웃을 보고 의견 주시면 감사하겠습니다..🥹

🐕 이후 계획
 - 전체 페이지 반응형 웹 적용
 - 검색 결과 페이지 기능 구현