### PR TITLE
[Fix] : member post, patch시 mbti 유효성 검사 오류 수정

### DIFF
--- a/client/src/Pages/Member/Join.tsx
+++ b/client/src/Pages/Member/Join.tsx
@@ -148,7 +148,7 @@ function Join() {
 		'ESFP',
 		'INFJ',
 		'INFP',
-		'ENTJ',
+		'ENFJ',
 		'ENFP',
 		'ISTJ',
 		'ISFJ',

--- a/client/src/Pages/Member/UserEdit.tsx
+++ b/client/src/Pages/Member/UserEdit.tsx
@@ -101,7 +101,7 @@ function UserEdit() {
 		'ESFP',
 		'INFJ',
 		'INFP',
-		'ENTJ',
+		'ENFJ',
 		'ENFP',
 		'ISTJ',
 		'ISFJ',


### PR DESCRIPTION
member post, patch시 mbti 유효성 검사할때 'ENFJ'가 없고  'ENTJ'가 2개 있어서 수정