### PR TITLE
[feat] : 여행지 상세 페이지 페이지네이션 적용 & 상세 설명 문자열 치환 & CSS 수정

### DIFF
--- a/client/src/Components/mainpage/CarouselNearbyPlace.tsx
+++ b/client/src/Components/mainpage/CarouselNearbyPlace.tsx
@@ -89,7 +89,7 @@ function CarouselNearbyPlace() {
 	});
 
 	const tourAPIKey = process.env.REACT_APP_TOURAPI_KEY;
-	const tourUrl = `https://apis.data.go.kr/B551011/KorService1/locationBasedList1?serviceKey=${tourAPIKey}&numOfRows=6&pageNo=1&MobileOS=ETC&MobileApp=AppTest&_type=json&listYN=Y&arrange=Q&mapX=${myLocation.longitude}&mapY=${myLocation.latitude}&radius=10000&contentTypeId=12`;
+	const tourUrl = `https://apis.data.go.kr/B551011/KorService1/locationBasedList1?serviceKey=${tourAPIKey}&numOfRows=8&pageNo=1&MobileOS=ETC&MobileApp=AppTest&_type=json&listYN=Y&arrange=Q&mapX=${myLocation.longitude}&mapY=${myLocation.latitude}&radius=10000&contentTypeId=12`;
 
 	const [tripInfo, setTripInfo] = useState([]);
 

--- a/client/src/Components/mainpage/CarouselReview.tsx
+++ b/client/src/Components/mainpage/CarouselReview.tsx
@@ -8,7 +8,7 @@ import { Link } from 'react-router-dom';
 import Slider, { Settings } from 'react-slick';
 import styled from 'styled-components';
 
-import useAxios from '../../hooks/useAxios';
+import useGet from '../../hooks/useGet';
 import { IImageProps } from '../../type/IImageProps';
 
 interface IReview {
@@ -140,23 +140,17 @@ function CarouselReview() {
 		],
 	};
 
-	const res: any = useAxios({
-		method: 'get',
-		url: '/posts',
-	}).response;
+	const response: any = useGet('?subject=여행리뷰&page=1');
 
 	useEffect(() => {
-		if (res !== null) {
-			const newData = res.filter(
-				(item: { subject: string }) => item.subject === '여행리뷰',
-			);
-			newData.sort(
+		if (response !== null) {
+			response.sort(
 				(a: { voteCount: number }, b: { voteCount: number }) =>
 					b.voteCount - a.voteCount,
 			);
-			setFilterReview(newData.slice(0, 5));
+			setFilterReview(response.slice(0, 5));
 		}
-	}, [res]);
+	}, [response]);
 
 	return (
 		<div>

--- a/client/src/Components/mainpage/MainHeader.tsx
+++ b/client/src/Components/mainpage/MainHeader.tsx
@@ -22,22 +22,22 @@ const MainHeaderContainer = styled.div`
 		height: 40vh;
 		opacity: 0.5;
 		z-index: -1;
-		@media (max-width: 583px) {
-			height: 300px;
-		}
 		@media (max-width: 768px) {
 			height: 35vh;
 		}
+		@media (max-width: 583px) {
+			height: 300px;
+		}
 	}
-	@media (max-width: 583px) {
-		height: 300px;
+	@media (max-width: 1024px) {
+		padding: 40px;
 	}
 	@media (max-width: 768px) {
 		padding: 20px;
 		height: 35vh;
 	}
-	@media (max-width: 1024px) {
-		padding: 40px;
+	@media (max-width: 583px) {
+		height: 300px;
 	}
 `;
 
@@ -45,12 +45,14 @@ const MainText = styled.div`
 	font-size: 50px;
 	font-weight: 900;
 	background-color: transparent;
-	@media (max-width: 582px) {
-		padding: 20px;
-		height: 30vh;
+	@media (max-width: 1024px) {
+		font-size: 1.8rem;
 	}
 	@media (max-width: 768px) {
-		font-size: 2rem;
+		font-size: 1.6rem;
+	}
+	@media (max-width: 425px) {
+		font-size: 1.3rem;
 	}
 	> span {
 		color: #0db4f3;
@@ -60,9 +62,14 @@ const MainText = styled.div`
 		width: 320px;
 		font-size: 40px;
 		margin-top: 20px;
+		@media (max-width: 1024px) {
+			font-size: 1.8rem;
+		}
 		@media (max-width: 768px) {
-			width: 100%;
-			font-size: 2rem;
+			font-size: 1.6rem;
+		}
+		@media (max-width: 425px) {
+			font-size: 1.3rem;
 		}
 	}
 `;

--- a/client/src/Components/mainpage/Modal.tsx
+++ b/client/src/Components/mainpage/Modal.tsx
@@ -20,8 +20,18 @@ const ModalButton = styled.button`
 	background-color: #0db4f3;
 	color: white;
 	margin-top: 10px;
-	width: 60px;
+	width: 15%;
+	padding: 10px;
 	border-radius: 15px;
+	@media (max-width: 768px) {
+		width: 20%;
+	}
+	@media (max-width: 425px) {
+		width: 35%;
+	}
+	@media (max-width: 335px) {
+		width: 40%;
+	}
 `;
 
 const ModalView = styled.div`
@@ -29,13 +39,21 @@ const ModalView = styled.div`
 	top: 30vh;
 	left: 15vw;
 	width: 70%;
+	height: 40%;
+	overflow-y: scroll;
 	background-color: white;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
 	border-radius: 15px;
-	padding: 20px;
+	padding: 20px 30px 30px 30px;
+	line-height: 1.5;
+	font-size: 1.3em;
+	@media (max-width: 425px) {
+		width: 80%;
+		left: 10vw;
+	}
 `;
 
 type ModalProps = {

--- a/client/src/Components/mainpage/UserHeader.tsx
+++ b/client/src/Components/mainpage/UserHeader.tsx
@@ -26,34 +26,36 @@ const UserHeaderContainer = styled.div<IImageProps>`
 		height: 40vh;
 		opacity: 0.8;
 		z-index: -1;
-		@media (max-width: 583px) {
-			height: 300px;
-		}
 		@media (max-width: 768px) {
 			height: 35vh;
 		}
+		@media (max-width: 583px) {
+			height: 300px;
+		}
 	}
-	@media (max-width: 583px) {
-		height: 300px;
+	@media (max-width: 1024px) {
+		padding: 40px;
 	}
 	@media (max-width: 768px) {
 		padding: 20px;
 		height: 35vh;
 	}
-	@media (max-width: 1024px) {
-		padding: 40px;
+	@media (max-width: 583px) {
+		height: 300px;
 	}
 `;
 
 const HeaderText = styled.div`
 	font-size: 50px;
 	font-weight: 700;
-	@media (max-width: 582px) {
-		padding: 20px;
-		height: 30vh;
+	@media (max-width: 1024px) {
+		font-size: 1.8rem;
 	}
 	@media (max-width: 768px) {
-		font-size: 2rem;
+		font-size: 1.6rem;
+	}
+	@media (max-width: 425px) {
+		font-size: 1.3rem;
 	}
 	.emphasis {
 		color: #0db4f3;
@@ -66,9 +68,14 @@ const HeaderText = styled.div`
 		font-weight: 700;
 		margin-top: 20px;
 		background-color: rgba(255, 255, 255, 0.7);
+		@media (max-width: 1024px) {
+			font-size: 1.8rem;
+		}
 		@media (max-width: 768px) {
-			width: 100%;
-			font-size: 2rem;
+			font-size: 1.4rem;
+		}
+		@media (max-width: 425px) {
+			font-size: 1.1rem;
 		}
 	}
 `;

--- a/client/src/pages/common/MainPage.tsx
+++ b/client/src/pages/common/MainPage.tsx
@@ -70,7 +70,7 @@ const MainTabButton = styled.div`
 const MainContentsContainer = styled.div`
 	width: 95%;
 	height: 650px;
-	border-radius: 50px 50px 0 0;
+	border-radius: 50px;
 	box-shadow: 0px 2px 11px 1px #999999;
 	margin: 20px 10px;
 	display: flex;

--- a/client/src/pages/contents/HotReview.tsx
+++ b/client/src/pages/contents/HotReview.tsx
@@ -82,6 +82,7 @@ const HotReviewItem = styled.div`
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
+		align-items: center;
 	}
 `;
 
@@ -101,20 +102,16 @@ const HotReviewImg = styled.div<IImageProps>`
 `;
 
 const HotReviewInfo = styled.div`
-	width: 70%;
+	width: 90%;
 	margin-left: 20px;
 	display: flex;
 	flex-direction: column;
-	> span {
-		margin: 10px;
-		font-size: 20px;
-		@media (max-width: 768px) {
-			width: 80vw;
-			margin-left: 0;
-		}
-	}
+	font-size: 20px;
 	@media (max-width: 768px) {
-		margin-left: 0;
+		margin-left: 10px;
+	}
+	@media (min-width: 768px) {
+		width: 70%;
 	}
 	.hotReviewBold {
 		font-size: 28px;
@@ -123,10 +120,14 @@ const HotReviewInfo = styled.div`
 			margin: 20px 0 0 0;
 		}
 	}
+	.hotReviewText {
+		margin: 15px 0px;
+	}
 	.hotReviewAuthor {
 		font-size: 24px;
 		font-weight: 700;
 		text-align: end;
+		margin-top: 20px;
 	}
 `;
 
@@ -137,6 +138,15 @@ const StyledLink = styled(Link)`
 	}
 	&:visited {
 		color: black;
+	}
+`;
+
+const HotReviewNotice = styled.div`
+	border-bottom: 1px solid #adadad;
+	font-size: 28px;
+	padding-bottom: 20px;
+	@media (max-width: 768px) {
+		font-size: 22px;
 	}
 `;
 
@@ -161,6 +171,10 @@ function HotReview() {
 				<span>🔥 인기 여행 리뷰 TOP5</span>
 			</HotReviewImage>
 			<HotReviewItemContainer>
+				<HotReviewNotice>
+					💡 최근 한 달 동안 사용자들에게 가장 인기가 많았던 리뷰들을
+					소개합니다!
+				</HotReviewNotice>
 				{filterdReview
 					? filterdReview.map((item) => (
 							<StyledLink
@@ -170,14 +184,14 @@ function HotReview() {
 								<HotReviewItem key={item.id}>
 									<HotReviewImg image={item.img[0]} />
 									<HotReviewInfo>
-										<span className="hotReviewBold">{item.title}</span>
-										<span className="hotReviewBold">💙 {item.voteCount}</span>
-										<span>{item.content}</span>
-										<span className="hotReviewAuthor">
+										<div className="hotReviewBold">{item.title}</div>
+										<div className="hotReviewBold">💙 {item.voteCount}</div>
+										<div className="hotReviewText">{item.content}</div>
+										<div className="hotReviewAuthor">
 											{item.nickName}
 											<br />
 											{item.createdAt?.slice(0, 8)}
-										</span>
+										</div>
 									</HotReviewInfo>
 								</HotReviewItem>
 							</StyledLink>

--- a/client/src/pages/contents/HotReview.tsx
+++ b/client/src/pages/contents/HotReview.tsx
@@ -173,7 +173,11 @@ function HotReview() {
 										<span className="hotReviewBold">{item.title}</span>
 										<span className="hotReviewBold">💙 {item.voteCount}</span>
 										<span>{item.content}</span>
-										<span className="hotReviewAuthor">{item.nickName}</span>
+										<span className="hotReviewAuthor">
+											{item.nickName}
+											<br />
+											{item.createdAt?.slice(0, 8)}
+										</span>
 									</HotReviewInfo>
 								</HotReviewItem>
 							</StyledLink>

--- a/client/src/pages/contents/HotReview.tsx
+++ b/client/src/pages/contents/HotReview.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-import useAxios from '../../hooks/useAxios';
+import useGet from '../../hooks/useGet';
 import { IImageProps } from '../../type/IImageProps';
 
 interface IReview {
@@ -53,8 +53,11 @@ const HotReviewImage = styled.div`
 		font-weight: 900;
 		color: white;
 		margin: 20px;
+		@media (max-width: 768px) {
+			font-size: 38px;
+		}
 		@media (max-width: 425px) {
-			font-size: 36px;
+			font-size: 30px;
 		}
 	}
 `;
@@ -140,23 +143,17 @@ const StyledLink = styled(Link)`
 function HotReview() {
 	const [filterdReview, setFilterReview] = useState<IReview[]>([]);
 
-	const res: any = useAxios({
-		method: 'get',
-		url: '/posts',
-	}).response;
+	const response: any = useGet('?subject=여행리뷰&page=1');
 
 	useEffect(() => {
-		if (res !== null) {
-			const newData = res.filter(
-				(item: { subject: string }) => item.subject === '여행리뷰',
-			);
-			newData.sort(
+		if (response !== null) {
+			response.sort(
 				(a: { voteCount: number }, b: { voteCount: number }) =>
 					b.voteCount - a.voteCount,
 			);
-			setFilterReview(newData.slice(0, 5));
+			setFilterReview(response.slice(0, 5));
 		}
-	}, [res]);
+	}, [response]);
 
 	return (
 		<HotReviewContainer>

--- a/client/src/pages/contents/NearbyPlace.tsx
+++ b/client/src/pages/contents/NearbyPlace.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-icons/ti';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import Pagination from '../../Components/community/Pagination';
 import Modal from '../../Components/mainpage/Modal';
 import { IImageProps } from '../../type/IImageProps';
 import { TripInfoType } from '../../type/ITripInfo';
@@ -251,7 +252,8 @@ function NearbyPlace() {
 	};
 
 	const tourAPIKey = process.env.REACT_APP_TOURAPI_KEY;
-	const tourUrl = `https://apis.data.go.kr/B551011/KorService1/locationBasedList1?serviceKey=${tourAPIKey}&numOfRows=6&pageNo=1&MobileOS=ETC&MobileApp=AppTest&_type=json&listYN=Y&arrange=Q&mapX=${myLocation.longitude}&mapY=${myLocation.latitude}&radius=10000&contentTypeId=12`;
+	const [curPage, setCurPage] = useState(1);
+	const tourUrl = `https://apis.data.go.kr/B551011/KorService1/locationBasedList1?serviceKey=${tourAPIKey}&numOfRows=6&pageNo=${curPage}&MobileOS=ETC&MobileApp=AppTest&_type=json&listYN=Y&arrange=Q&mapX=${myLocation.longitude}&mapY=${myLocation.latitude}&radius=10000&contentTypeId=12`;
 
 	const [tripInfo, setTripInfo] = useState([]);
 
@@ -273,7 +275,8 @@ function NearbyPlace() {
 				const { data } = response;
 				const intro = data.response.body.items.item[0].overview;
 				setIsOpen(true);
-				setTourText(intro);
+				const textReplace = /<br\s*\/?>/gi;
+				setTourText(intro.replace(textReplace, ''));
 			})
 			.catch(() => {
 				navigate('/error');
@@ -331,6 +334,14 @@ function NearbyPlace() {
 					  })
 					: null}
 			</NearbyPlaceRecItemContainer>
+			<Pagination
+				curPage={curPage}
+				setCurPage={setCurPage}
+				totalPage={9}
+				totalCount={54}
+				size={6}
+				pageCount={3}
+			/>
 		</NearbyPlaceContainer>
 	);
 }

--- a/client/src/pages/contents/NearbyPlace.tsx
+++ b/client/src/pages/contents/NearbyPlace.tsx
@@ -37,6 +37,12 @@ const NearbyPlaceDetailImage = styled.div<IImageProps>`
 		font-weight: 900;
 		color: white;
 		margin: 20px;
+		@media (max-width: 768px) {
+			font-size: 38px;
+		}
+		@media (max-width: 425px) {
+			font-size: 30px;
+		}
 	}
 	&::before {
 		background: ${(props) => (props.image ? `url(${props.image})` : `url('')`)}
@@ -81,6 +87,11 @@ const NearbyPlaceInfoText = styled.div`
 	font-size: 18px;
 	@media (max-width: 768px) {
 		width: 100%;
+	}
+	.notice {
+		margin-top: 20px;
+		font-size: 18px;
+		color: #adadad;
 	}
 `;
 
@@ -166,6 +177,8 @@ const WeatherDetail = styled.div`
 
 const backgroundImg =
 	'https://images.unsplash.com/photo-1601621915196-2621bfb0cd6e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1744&q=80';
+const thumbnail =
+	'https://images.unsplash.com/photo-1625603736199-775425d2890a?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80';
 
 function NearbyPlace() {
 	const navigate = useNavigate();
@@ -274,7 +287,7 @@ function NearbyPlace() {
 				<span>🧭 우리 동네 추천 명소</span>
 			</NearbyPlaceDetailImage>
 			<NearbyPlaceInfo>
-				<NearbyPlaceInfoImg image={backgroundImg} />
+				<NearbyPlaceInfoImg image={thumbnail} />
 				<NearbyPlaceInfoText>
 					<Weather>
 						<WeatherTitle>
@@ -291,6 +304,9 @@ function NearbyPlace() {
 					<br />
 					가까워서 미처 알지 못했던 여행지를 추천 받아, 오늘 바로 떠나보시는건
 					어떨까요?
+					<div className="notice">
+						여행지를 클릭하면 여행지에 대한 자세한 설명을 볼 수 있습니다.
+					</div>
 				</NearbyPlaceInfoText>
 			</NearbyPlaceInfo>
 			<NearbyPlaceTitle>

--- a/client/src/pages/contents/RegionDetail.tsx
+++ b/client/src/pages/contents/RegionDetail.tsx
@@ -89,9 +89,14 @@ const RegionInfoImg = styled.div<IImageProps>`
 const RegionInfoText = styled.div`
 	width: 60%;
 	padding-left: 20px;
-	font-size: 18px;
+	font-size: 20px;
 	@media (max-width: 768px) {
 		width: 100%;
+	}
+	.notice {
+		margin-top: 20px;
+		font-size: 18px;
+		color: #adadad;
 	}
 `;
 
@@ -494,6 +499,9 @@ function RegionDetail() {
 						</WeatherDetail>
 					</Weather>
 					{selectedRegion[0].regionIntro}
+					<div className="notice">
+						여행지를 클릭하면 여행지에 대한 자세한 설명을 볼 수 있습니다.
+					</div>
 				</RegionInfoText>
 			</RegionInfo>
 			<RegionTitle>

--- a/client/src/pages/contents/RegionDetail.tsx
+++ b/client/src/pages/contents/RegionDetail.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-icons/ti';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import Pagination from '../../Components/community/Pagination';
 import Modal from '../../Components/mainpage/Modal';
 import { IImageProps } from '../../type/IImageProps';
 import { TripInfoType } from '../../type/ITripInfo';
@@ -447,7 +448,8 @@ function RegionDetail() {
 		}
 	};
 	const tourAPIKey = process.env.REACT_APP_TOURAPI_KEY;
-	const tourUrl = `http://apis.data.go.kr/B551011/KorService1/areaBasedList1?serviceKey=${tourAPIKey}&pageNo=1&numOfRows=6&MobileApp=AppTest&MobileOS=ETC&arrange=Q&contentTypeId=12&areaCode=${selectedRegion[0].areaCode}&_type=json`;
+	const [curPage, setCurPage] = useState(1);
+	const tourUrl = `http://apis.data.go.kr/B551011/KorService1/areaBasedList1?serviceKey=${tourAPIKey}&pageNo=${curPage}&numOfRows=6&MobileApp=AppTest&MobileOS=ETC&arrange=Q&contentTypeId=12&areaCode=${selectedRegion[0].areaCode}&_type=json`;
 
 	const [tripInfo, setTripInfo] = useState([]);
 
@@ -472,7 +474,8 @@ function RegionDetail() {
 				const { data } = response;
 				const intro = data.response.body.items.item[0].overview;
 				setIsOpen(true);
-				setTourText(intro);
+				const textReplace = /<br\s*\/?>/gi;
+				setTourText(intro.replace(textReplace, ''));
 			})
 			.catch(() => {
 				navigate('/error');
@@ -526,6 +529,14 @@ function RegionDetail() {
 					  })
 					: null}
 			</RegionRecItemContainer>
+			<Pagination
+				curPage={curPage}
+				setCurPage={setCurPage}
+				totalPage={9}
+				totalCount={54}
+				size={6}
+				pageCount={3}
+			/>
 		</RegionDetailContainer>
 	);
 }

--- a/client/src/pages/contents/RegionRecommend.tsx
+++ b/client/src/pages/contents/RegionRecommend.tsx
@@ -39,6 +39,12 @@ const RegionRecImage = styled.div`
 		font-weight: 900;
 		color: white;
 		margin: 20px;
+		@media (max-width: 768px) {
+			font-size: 38px;
+		}
+		@media (max-width: 425px) {
+			font-size: 30px;
+		}
 	}
 	@media (max-width: 768px) {
 		height: 30vh;
@@ -69,7 +75,7 @@ const RegionRecImg = styled.div<IImageProps>`
 	border-radius: 15px;
 	text-align: center;
 	> div {
-		line-height: 270px;
+		line-height: 260px;
 	}
 `;
 


### PR DESCRIPTION
🐕 수정사항
<img width="851" alt="스크린샷 2023-05-24 04 22 10" src="https://github.com/codestates-seb/seb43_main_023/assets/119163273/69bb0d7c-d056-4e69-9944-f67a4d1b6195">
 - 상세 페이지 상단에 여행지 설명을 볼 수 있게 클릭을 유도하는 문구를 작성했습니다.
<img width="822" alt="스크린샷 2023-05-24 04 22 37" src="https://github.com/codestates-seb/seb43_main_023/assets/119163273/53b3c406-5b5c-492a-96fd-72df5d1c0bff">

 - 상세 페이지에 페이지네이션을 적용하고, 컨텐츠는 한 페이지에 6개씩 9페이지로 배치했습니다.
<img width="910" alt="스크린샷 2023-05-24 04 23 01" src="https://github.com/codestates-seb/seb43_main_023/assets/119163273/3e320a18-c461-4b51-9e40-006249b5c42e">

 - 상세 설명을 조회할 때 줄바꿈 태그가 string 내부에 존재하는 경우 삭제합니다.
<img width="913" alt="스크린샷 2023-05-24 04 24 20" src="https://github.com/codestates-seb/seb43_main_023/assets/119163273/cdb33b96-a302-473e-8e2f-593207f1551f">

 - 인기 리뷰 페이지에 작성자 하단에 게시글이 작성된 날짜를 추가하였습니다.
 - 인기 리뷰가 최근 1개월 이내에 작성된 여행 리뷰 중 추천수가 높은 순으로 정렬된 데이터로 변경되었습니다.
 - 반응형 웹이 깨지는 부분을 소폭 수정하였습니다.


🐕 이후 계획
 - 발표 자료 준비
 - 디테일 수정